### PR TITLE
:heavy_minus_sign: removed flux-core as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "flux-core"]
-	path = flux-core
-	url = https://github.com/flux-framework/flux-core.git


### PR DESCRIPTION
We will be switching to using [RTD Subprojects](https://docs.readthedocs.io/en/stable/subprojects.html) instead of git submodules.