### PR TITLE
quickstart.rst: unify all example output under a common username

### DIFF
--- a/quickstart.rst
+++ b/quickstart.rst
@@ -92,7 +92,7 @@ Clone current flux-sched master:
 
 Build flux-sched. By default, flux-sched will attempt to configure against
 flux-core found in the specified ``--prefix`` using the same
-``PYTHON_VERSION``::
+``PYTHON_VERSION``:
 
 .. code-block:: console
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -53,7 +53,7 @@ Clone current flux-core master:
 .. code-block:: console
 
   $ git clone https://github.com/flux-framework/flux-core.git
-  Initialized empty Git repository in /home/user1/flux-core/.git/
+  Initialized empty Git repository in /home/fluxuser/flux-core/.git/
   $ cd flux-core
 
 Build flux-core. In order to build python bindings, ensure you have python-3.6 and python-cffi available in your current environment:
@@ -87,7 +87,7 @@ Clone current flux-sched master:
 .. code-block:: console
 
   $ git clone https://github.com/flux-framework/flux-sched.git
-  Initialized empty Git repository in /home/user1/flux-sched/.git/
+  Initialized empty Git repository in /home/fluxuser/flux-sched/.git/
   $ cd flux-sched
 
 Build flux-sched. By default, flux-sched will attempt to configure against
@@ -127,10 +127,10 @@ Before a Flux instance can be started, keys must be generated to encrypt and aut
 .. code-block:: console
 
   $ flux keygen
-  Saving /home/user1/.flux/curve/client
-  Saving /home/user1/.flux/curve/client_private
-  Saving /home/user1/.flux/curve/server
-  Saving /home/user1/.flux/curve/server_private
+  Saving /home/fluxuser/.flux/curve/client
+  Saving /home/fluxuser/.flux/curve/client_private
+  Saving /home/fluxuser/.flux/curve/server
+  Saving /home/fluxuser/.flux/curve/server_private
   $
 
 To start a Flux session with 4 brokers on the local node, use ``flux start``:
@@ -326,6 +326,6 @@ Here, the allocated ID for the job is immediately echoed to stdout.
 .. code-block:: console
 
   $ flux jobs
-          JOBID USER     NAME       STATE    NTASKS NNODES  RUNTIME RANKS
-  1378382512128 user1    sleep      RUN           1      1   5.015s 0
-  1355649384448 user1    sleep      RUN           1      1   6.368s 0
+          JOBID USER        NAME       STATE    NTASKS NNODES  RUNTIME RANKS
+  1378382512128 fluxuser    sleep      RUN           1      1   5.015s 0
+  1355649384448 fluxuser    sleep      RUN           1      1   6.368s 0


### PR DESCRIPTION
As mentioned in #26:

> As noted in #25, example output in the quickstart guide uses real usernames, and thus usernames may not match across all examples.

@SteVwonder had already changed the usernames to `user1` in PR #25, but since the issue wasn't closed, I went ahead and changed the usernames in **quickstart.rst** to `fluxuser`.

There was also a small formatting issue in **quickstart.rst** where the code block following the 'Build flux-sched' instruction was not rendered properly because of an extra colon, so I went ahead and removed the extra char and stacked another commit on top of this PR.   