### PR TITLE
Update CORAL-specific instructions for latest Spectrum updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        pre-build-command: >-
-          apt-get update -y &&
-          apt-get install -y enchant &&
-          pip install -r requirements.txt --upgrade
-        build-command: 'make check'
-        docs-folder: './'
+    - name: install dependencies
+      run: >-
+          sudo apt-get update -y &&
+          sudo apt-get install -y enchant python3-pip &&
+          sudo pip3 install --upgrade -r ./requirements.txt
+    - name: make check
+      run: 'make check'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: ammaraskar/sphinx-action@master
       with:
-        pre-build-command: "apt-get update -y && apt-get install -y enchant"
+        pre-build-command: >-
+          apt-get update -y &&
+          apt-get install -y enchant &&
+          pip install -r requirements.txt --upgrade
         build-command: 'make check'
         docs-folder: './'

--- a/coral.rst
+++ b/coral.rst
@@ -31,11 +31,11 @@ Launching Flux on CORAL systems requires a shim layer to provide `PMI
 <https://www.mcs.anl.gov/papers/P1760.pdf>`_ on top of the PMIx interface
 provided by the CORAL system launcher jsrun.  PMI is a common interface
 for bootstrapping parallel applications like MPI, SHMEM, and Flux.  To load this
-module, run:
+module along with our side-installed Flux, run:
 
 .. code-block:: sh
 
-  module load pmi-shim
+  module load pmi-shim flux
 
 We also suggest that you launch Flux using jsrun with the following arguments:
 

--- a/coral.rst
+++ b/coral.rst
@@ -41,7 +41,7 @@ We also suggest that you launch Flux using jsrun with the following arguments:
 
 .. code-block:: sh
 
-  PMIX_MCA_gds="^ds12,ds21" jsrun -a 1 -c ALL_CPUS -g ALL_GPUS --bind=none -n ${NUM_NODES} flux start
+  PMIX_MCA_gds="^ds12,ds21" jsrun -a 1 -c ALL_CPUS -g ALL_GPUS -n ${NUM_NODES} --bind=none --smpiargs="-disable_gpu_hooks" flux start
 
 The ``PMIX_MCA_gds`` environment variable works around `a bug in OpenPMIx
 <https://github.com/openpmix/openpmix/issues/1396>`_ that causes a hang when


### PR DESCRIPTION
The latest Spectrum version requires a flag to disable the loading of a pami gpu library that segfaults when not run directly under jsrun (e.g., when Flux is bootstrapping).

Also include the instruction to load our `flux` module to access side installs of Flux.

I manually tested the updated instructions on both Lassen and Summit.  I don't think the `-disable_gpu_hooks` flag does anything on Summit since they are running an older Spectrum version, but thankfully, `jsrun` and Spectrum MPI do not complain when it is provided.