### PR TITLE
readthedocs: add top-level ReadTheDocs (RTD) config yaml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the top-level directory with Sphinx
+sphinx:
+  configuration: conf.py
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Pygments>=2.4
 Sphinx
 sphinxcontrib-spelling
 sphinx-rtd-theme


### PR DESCRIPTION
Problem: RTD switched from primarily configuring builds via their web interface to using version control yaml files. Additionally, the build is currently using an old version of Pygments that does not support syntax highlighting of toml.

Solution: kill two birds with one stone by adding an RTD top-level config yaml that requests python 3.7 and then request a newer version of Pygments (which requires py3.5+).

Closes #64 