### PR TITLE
Add Workflow Examples and Improve Section/Reference Titles

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,10 @@ intersphinx_mapping = {
         "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/",
         None,
     ),
+    "workflow-examples": (
+        "https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/",
+        None,
+    ),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -48,6 +48,11 @@ API Reference
 - :doc:`rfc:index`
 
 
+Workflow Examples
+-----------------
+
+- :doc:`workflow-examples:index`
+
 Indices and tables
 ==================
 

--- a/index.rst
+++ b/index.rst
@@ -36,16 +36,16 @@ Contributor Relevant RFCs
 - :doc:`rfc:spec_9`
 
 
-Command Reference
------------------
-
-- :doc:`core:index`
-
-
-API Reference
--------------
+All RFCs
+--------
 
 - :doc:`rfc:index`
+
+
+Manual Pages
+------------
+
+- :ref:`core:man-pages`
 
 
 Workflow Examples

--- a/index.rst
+++ b/index.rst
@@ -26,6 +26,15 @@ The framework consists of a suite of projects, tools, and libraries which may be
    batch
    faqs
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Sub-Projects
+   :hidden:
+
+   flux-core <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/index.html>
+   RFCs <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/index.html>
+   Workflow Examples <https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/index.html>
+
 
 Contributor Relevant RFCs
 -------------------------


### PR DESCRIPTION
Adds a subsection to `index.rst` that references the new flux-workflow-examples docs.
Improves the section and reference titles for flux-core and flux-rfcs.

Closes #75, #76

Depends on https://github.com/flux-framework/flux-core/pull/3365