### PR TITLE
faqs: change openmpi version number 4.0.2 -> 4.0.1

### DIFF
--- a/faqs.rst
+++ b/faqs.rst
@@ -128,7 +128,7 @@ Flux plugins were added to OpenMPI 3.0.0.  Generally, these plugins enable OpenM
                  MCA pmix: flux (MCA v2.1.0, API v2.0.0, Component v4.0.3)
                MCA schizo: flux (MCA v2.1.0, API v1.0.0, Component v4.0.3)
 
-Unfortunately, `an OpenMPI bug <https://github.com/open-mpi/ompi/issues/6730>`_ broke the Flux plugins in OpenMPI versions 3.0.0-3.0.4, 3.1.0-3.1.4, and 4.0.0-4.0.2.  The `fix <https://github.com/open-mpi/ompi/pull/6764/commits/d4070d5f58f0c65aef89eea5910b202b8402e48b>`_ was backported such that the 3.0.5+, 3.1.5+, and 4.0.2+ series do not experience this issue.
+Unfortunately, `an OpenMPI bug <https://github.com/open-mpi/ompi/issues/6730>`_ broke the Flux plugins in OpenMPI versions 3.0.0-3.0.4, 3.1.0-3.1.4, and 4.0.0-4.0.1.  The `fix <https://github.com/open-mpi/ompi/pull/6764/commits/d4070d5f58f0c65aef89eea5910b202b8402e48b>`_ was backported such that the 3.0.5+, 3.1.5+, and 4.0.2+ series do not experience this issue.
 
 A slightly different `OpenMPI bug <https://github.com/open-mpi/ompi/pull/8380>`_ caused segfaults of MPI in ``MPI_Finalize`` when UCX PML was used.  `The fix <https://github.com/open-mpi/ompi/pull/8380>`_ was backported to 4.0.6 and 4.1.1.  If you are using UCX PML in OpenMPI, we recommend using 4.0.6+ or 4.1.1+.
 


### PR DESCRIPTION
Problem: faq states that 4.0.2+ works, but also says a bug
affected versions _through_ 4.0.2.

I think the bug affects 4.0.1 but not 4.0.2, so state that the
bug affects versions through 4.0.1.