### PR TITLE
update admin guide for flux-core v0.26.0

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -13,12 +13,12 @@ resource manager on a cluster.
     in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-core
-    version 0.22.0.
+    version 0.26.0.
 
 .. warning::
-    0.22.0 limitation: system instance size should not exceed 256 nodes.
+    0.26.0 limitation: system instance size should not exceed 256 nodes.
 
-    0.22.0 limitation: node failure detection is minimal in this release.
+    0.26.0 limitation: node failure detection is minimal in this release.
     Avoid powering off nodes that are running Flux without following the
     recommended shutdown procedure below.  Cluster nodes that may require
     service or have connectivity issues should be omitted from the Flux
@@ -106,10 +106,13 @@ Do this once and then copy the certificate to the same location on
 the other nodes, preserving owner and mode.
 
 .. note::
-    0.22.0 changed the way CURVE certificates are generated and configured.
-    When upgrading, generate a new certificate as described above, and add
-    ``curve_cert = "/etc/flux/system/curve.cert"`` to the ``[bootstrap]``
-    configuration.
+    The way CURVE certificates are generated and configured was changed as
+    of flux-core v0.22.0.  When upgrading from earlier versions, generate a
+    new certificate as described above, and add
+
+    ``curve_cert = "/etc/flux/system/curve.cert"``
+
+    to the ``[bootstrap]`` configuration.
 
     You may remove the old certificates in the ``flux`` user's home directory
 
@@ -209,7 +212,7 @@ The overlay network may be configured to use any IP network that remains
 available the whole time Flux is running.
 
 .. warning::
-    0.22.0 limitation: the system instance tree based overlay network
+    0.26.0 limitation: the system instance tree based overlay network
     is forced by the systemd unit file to be *flat* (no interior router
     nodes), trading scalability for reliability.
 
@@ -246,7 +249,7 @@ preferably local.  Therefore, rank 0 ideally will be placed on a non-compute
 node along with other critical cluster services.
 
 .. warning::
-    0.22.0 limitation: Flux should be completely shut down when the
+    0.26.0 limitation: Flux should be completely shut down when the
     overlay network configuration is modified.
 
 .. _configuration-resource-exclusion:
@@ -298,8 +301,8 @@ An example resource configuration:
  exclude = "fluke[3,108]"
 
 .. note::
-    0.22.0 implements support for exclusion by hostlist.  It is suggested
-    that the previously configured exclusion rank idset be replaced with a
+    0.22.0 implemented support for exclusion by hostlist.  It is suggested
+    that any previously configured exclusion rank idset be replaced with a
     hostlist, which should be more convenient and less prone to error
     going forward.
 
@@ -324,13 +327,13 @@ This space should be preserved across a reboot as it contains the Flux
 job queue and record of past jobs.
 
 .. warning::
-    0.22.0 limitation: tools for shrinking the content.sqlite file or
+    0.26.0 limitation: tools for shrinking the content.sqlite file or
     purging old job data while retaining other content are not yet available.
 
-    0.22.0 limitation: Flux must be completely stopped to relocate or remove
+    0.26.0 limitation: Flux must be completely stopped to relocate or remove
     the content.sqlite file.
 
-    0.22.0 limitation: Running out of space is not handled gracefully.
+    0.26.0 limitation: Running out of space is not handled gracefully.
     If this happens it is best to stop Flux, remove the content.sqlite file,
     and restart.
 
@@ -378,7 +381,7 @@ To shut down a single node running Flux, simply run the above command
 on that node.
 
 .. warning::
-    0.22.0 limitation: jobs using a node are not automatically canceled
+    0.26.0 limitation: jobs using a node are not automatically canceled
     when the individual node is shut down.  On an active system, first drain
     the node as described below, then ensure no jobs are using it before
     shutting it down.
@@ -405,7 +408,7 @@ at the time of the next job execution, since these components are executed
 at job launch.
 
 .. warning::
-    0.22.0 limitation: all configuration changes except resource exclusion
+    0.26.0 limitation: all configuration changes except resource exclusion
     and instance access have no effect until the Flux broker restarts.
 
 .. _resource-status:
@@ -635,13 +638,12 @@ components (e.g. ``flux-core``, ``flux-sched``, ``flux-security``,
 and ``flux-accounting``)  should only only be installed in recommended
 combinations.
 
-.. warning::
-    0.22.0 limitation: mismatched versions are not detected, thus
-    the effect of accidentally mixing versions of flux-core within
-    a Flux instance is unpredictable.
+.. note::
+    0.26.0 added support for detection of mismatched versions within an
+    instance. The version of Flux is currently required to match exactly.
 
 .. warning::
-    0.22.0 limitation: job data should be purged when updating to the
+    0.26.0 limitation: job data should be purged when updating to the
     next release of flux-core, as internal representations of data written
     out to the Flux KVS and stored in the content.sqlite file are not yet
     stable.


### PR DESCRIPTION
Update the Flux Administrator's Guide for flux-core v0.26.0.

Mostly this entailed replacing `0.22.0` with `0.26.0` to avoid confusion about the limitations of v0.26.0.