### PR TITLE
Update CORAL systems based on latest install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build
+venv

--- a/conf.py
+++ b/conf.py
@@ -51,6 +51,7 @@ if rtd_version not in ["stable", "latest"]:
 extensions = [
     "sphinx.ext.intersphinx",
     'sphinxcontrib.spelling',
+    'sphinx_copybutton',
 ]
 
 # sphinxcontrib.spelling settings

--- a/conf.py
+++ b/conf.py
@@ -65,7 +65,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
 
 master_doc = 'index'
 source_suffix = '.rst'

--- a/coral.rst
+++ b/coral.rst
@@ -21,7 +21,7 @@ If you are using the ORNL system Summit, run:
 
 .. code-block:: sh
 
-  module use /sw/summit/modulefiles/ums/gen007flux/Core
+  module use /sw/summit/modulefiles/ums/gen007flux/linux-rhel8-ppc64le/Core
 
 ------------------
 Launching Flux

--- a/coral.rst
+++ b/coral.rst
@@ -15,6 +15,7 @@ Sierra, run:
 
 .. code-block:: sh
 
+  module use /usr/tce/modulefiles/Core # if not already in use
   module use /usr/global/tools/flux/blueos_3_ppc64le_ib/modulefiles
 
 If you are using the ORNL system Summit, run:
@@ -106,14 +107,8 @@ On all systems, Flux relies on hwloc to auto-detect the on-node resources
 available for scheduling.  The hwloc that Flux is linked against must be
 configured with ``--enable-cuda`` for Flux to be able to detect Nvidia GPUs.
 
-The ORNL CORAL `flux` module automatically loads an `hwloc` configured against
-the system default `cuda`. If running on an LLNL CORAL system, you can load a
-hwloc configured against the `cuda/10.1` in `/usr/tce` with:
-
-.. code-block:: sh
-
-  module use /usr/tce/modulefiles/Core # if not already in use
-  module load hwloc/1.11.13-cuda10.1
+The LLNL and ORNL CORAL ``flux`` modules automatically loads an ``hwloc`` configured
+against a system-provided ``cuda``.
 
 For all systems, you can test to see if the hwloc that Flux is linked against
 is CUDA-enabled by running:

--- a/coral.rst
+++ b/coral.rst
@@ -40,8 +40,8 @@ machines using:
   team and that is configured without ``--enabled-pmix-bootstrap`` (e.g., a
   spack-installed Flux), launching it on CORAL systems requires a shim layer to
   provide `PMI <https://www.mcs.anl.gov/papers/P1760.pdf>`_ on top of the PMIx
-  interface provided by the CORAL system launcher jsrun. To load this module
-  along with our side-installed Flux, run ``module load pmi-shim``.
+  interface provided by the CORAL system launcher ``jsrun``. To load this module
+  alongside your side-installed Flux, run ``module load pmi-shim``.
 
 We also suggest that you launch Flux using jsrun with the following arguments:
 

--- a/coral.rst
+++ b/coral.rst
@@ -27,27 +27,45 @@ If you are using the ORNL system Summit, run:
 Launching Flux
 ------------------
 
-Launching Flux on CORAL systems requires a shim layer to provide `PMI
-<https://www.mcs.anl.gov/papers/P1760.pdf>`_ on top of the PMIx interface
-provided by the CORAL system launcher jsrun.  PMI is a common interface
-for bootstrapping parallel applications like MPI, SHMEM, and Flux.  To load this
-module along with our side-installed Flux, run:
+You can load the latest Flux-team managed installation on LLNL and ORNL CORAL
+machines using:
 
 .. code-block:: sh
 
-  module load pmi-shim flux
+  module load flux
+
+.. note::
+
+  If you are using an installation of Flux that is not provided by the Flux
+  team and that is configured without ``--enabled-pmix-bootstrap`` (e.g., a
+  spack-installed Flux), launching it on CORAL systems requires a shim layer to
+  provide `PMI <https://www.mcs.anl.gov/papers/P1760.pdf>`_ on top of the PMIx
+  interface provided by the CORAL system launcher jsrun. To load this module
+  along with our side-installed Flux, run ``module load pmi-shim``.
 
 We also suggest that you launch Flux using jsrun with the following arguments:
 
 .. code-block:: sh
 
-  PMIX_MCA_gds="^ds12,ds21" jsrun -a 1 -c ALL_CPUS -g ALL_GPUS -n ${NUM_NODES} --bind=none --smpiargs="-disable_gpu_hooks" flux start
+  jsrun -a 1 -c ALL_CPUS -g ALL_GPUS -n ${NUM_NODES} --bind=none flux start
 
-The ``PMIX_MCA_gds`` environment variable works around `a bug in OpenPMIx
-<https://github.com/openpmix/openpmix/issues/1396>`_ that causes a hang when
-using the PMI compatibility shim.  The ``${NUM_NODES}`` variable is the number of
-nodes that you want to launch the Flux instance across. The remaining arguments
-ensure that all on-node resources are available to Flux for scheduling.
+The ``${NUM_NODES}`` variable is the number of nodes that you want to launch
+the Flux instance across. The remaining arguments ensure that all on-node
+resources are available to Flux for scheduling.
+
+.. note::
+
+  If you are using the ``pmi-shim`` module mentioned above, you will need to set
+  ``PMIX_MCA_gds="^ds12,ds21"`` in your environment before calling ``jsrun``. The
+  ``PMIX_MCA_gds`` environment variable works around `a bug in OpenPMIx
+  <https://github.com/openpmix/openpmix/issues/1396>`_ that causes a hang when
+  using the PMI compatibility shim.
+
+.. note::
+
+  If you are encountering segmentation faults in the OS's glibc, you can
+  potentially workaround the issue by passing
+  ``--smpiargs="-disable_gpu_hooks"`` to ``jsrun``.
 
 .. _coral_spectrum_mpi:
 
@@ -88,14 +106,17 @@ On all systems, Flux relies on hwloc to auto-detect the on-node resources
 available for scheduling.  The hwloc that Flux is linked against must be
 configured with ``--enable-cuda`` for Flux to be able to detect Nvidia GPUs.
 
-If running on an LLNL CORAL system, you can load a CUDA-enabled hwloc with:
+The ORNL CORAL `flux` module automatically loads an `hwloc` configured against
+the system default `cuda`. If running on an LLNL CORAL system, you can load a
+hwloc configured against the `cuda/10.1` in `/usr/tce` with:
 
 .. code-block:: sh
 
-  module load hwloc/1.11.10-cuda
+  module use /usr/tce/modulefiles/Core # if not already in use
+  module load hwloc/1.11.13-cuda10.1
 
-You can test to see if the hwloc that Flux is linked against is CUDA-enabled by
-running:
+For all systems, you can test to see if the hwloc that Flux is linked against
+is CUDA-enabled by running:
 
 .. code-block:: terminal
 

--- a/coral.rst
+++ b/coral.rst
@@ -44,7 +44,7 @@ machines using:
   interface provided by the CORAL system launcher ``jsrun``. To load this module
   alongside your side-installed Flux, run ``module load pmi-shim``.
 
-We also suggest that you launch Flux using jsrun with the following arguments:
+We also suggest that you launch Flux using ``jsrun`` with the following arguments:
 
 .. code-block:: sh
 
@@ -103,14 +103,14 @@ From the Python API, this looks like::
 Scheduling GPUs
 ---------------
 
-On all systems, Flux relies on hwloc to auto-detect the on-node resources
-available for scheduling.  The hwloc that Flux is linked against must be
+On all systems, Flux relies on ``hwloc`` to auto-detect the on-node resources
+available for scheduling.  The ``hwloc`` that Flux is linked against must be
 configured with ``--enable-cuda`` for Flux to be able to detect Nvidia GPUs.
 
 The LLNL and ORNL CORAL ``flux`` modules automatically loads an ``hwloc`` configured
 against a system-provided ``cuda``.
 
-For all systems, you can test to see if the hwloc that Flux is linked against
+For all systems, you can test to see if the ``hwloc`` that Flux is linked against
 is CUDA-enabled by running:
 
 .. code-block:: terminal
@@ -121,5 +121,5 @@ is CUDA-enabled by running:
     allocated      0        0        0
          down      0        0        0
 
-If the number of free GPUs is 0, then the hwloc that Flux is linked against is
+If the number of free GPUs is 0, then the ``hwloc`` that Flux is linked against is
 not CUDA-enabled.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pygments>=2.4
 Sphinx
 sphinxcontrib-spelling
 sphinx-rtd-theme
+sphinx-copybutton

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -488,3 +488,4 @@ subtree
 El
 Capitan
 Perlmutter
+glibc


### PR DESCRIPTION
The latest installations of Flux are much easier to use on the CORAL systems.  Update the documentation accordingly.

WIP while I wait to test the streamlined instructions on a multiple node allocation on Summit (been waiting in debug queue all day).