### PR TITLE
adminguide: update v0.29 references to v0.30

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -13,13 +13,13 @@ resource manager on a cluster.
     in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-core
-    version 0.29.0.
+    version 0.30.0.
 
 .. warning::
-    0.29.0 limitation: the flux system instance is primarily tested on
+    0.30.0 limitation: the flux system instance is primarily tested on
     a 128 node cluster.
 
-    0.29.0 limitation: Avoid powering off nodes that are running Flux
+    0.30.0 limitation: Avoid powering off nodes that are running Flux
     without following the recommended shutdown procedure below.  Cluster
     nodes that may require service or have connectivity issues should be
     omitted from the Flux configuration for now.
@@ -201,7 +201,7 @@ The overlay network may be configured to use any IP network that remains
 available the whole time Flux is running.
 
 .. warning::
-    0.29.0 limitation: the system instance tree based overlay network
+    0.30.0 limitation: the system instance tree based overlay network
     is forced by the systemd unit file to be *flat* (no interior router
     nodes), trading scalability for reliability.
 
@@ -238,7 +238,7 @@ preferably local.  Therefore, rank 0 ideally will be placed on a non-compute
 node along with other critical cluster services.
 
 .. warning::
-    0.29.0 limitation: Flux should be completely shut down when the
+    0.30.0 limitation: Flux should be completely shut down when the
     overlay network configuration is modified.
 
 .. _configuration-resource-exclusion:
@@ -310,13 +310,13 @@ This space should be preserved across a reboot as it contains the Flux
 job queue and record of past jobs.
 
 .. warning::
-    0.29.0 limitation: tools for shrinking the content.sqlite file or
+    0.30.0 limitation: tools for shrinking the content.sqlite file or
     purging old job data while retaining other content are not yet available.
 
-    0.29.0 limitation: Flux must be completely stopped to relocate or remove
+    0.30.0 limitation: Flux must be completely stopped to relocate or remove
     the content.sqlite file.
 
-    0.29.0 limitation: Running out of space is not handled gracefully.
+    0.30.0 limitation: Running out of space is not handled gracefully.
     If this happens it is best to stop Flux, remove the content.sqlite file,
     and restart.
 
@@ -364,7 +364,7 @@ To shut down a single node running Flux, simply run the above command
 on that node.
 
 .. warning::
-    0.29.0 limitation: jobs using a node are not automatically canceled
+    0.30.0 limitation: jobs using a node are not automatically canceled
     when the individual node is shut down.  On an active system, first drain
     the node as described below, then ensure no jobs are using it before
     shutting it down.
@@ -391,7 +391,7 @@ at the time of the next job execution, since these components are executed
 at job launch.
 
 .. warning::
-    0.29.0 limitation: all configuration changes except resource exclusion
+    0.30.0 limitation: all configuration changes except resource exclusion
     and instance access have no effect until the Flux broker restarts.
 
 .. _resource-status:
@@ -626,7 +626,7 @@ combinations.
     the instance.  The version is currently required to match exactly.
 
 .. warning::
-    0.29.0 limitation: job data should be purged when updating to the
+    0.30.0 limitation: job data should be purged when updating to the
     next release of flux-core, as internal representations of data written
     out to the Flux KVS and stored in the content.sqlite file are not yet
     stable.


### PR DESCRIPTION
flux-core v0.30.0 has been released and has all the same caveats
as v0.29.0, so update references in the admin guide.