### PR TITLE
admin guide: add flux-accounting setup section

### DIFF
--- a/spell.en.pws
+++ b/spell.en.pws
@@ -489,3 +489,5 @@ El
 Capitan
 Perlmutter
 glibc
+cron
+fairshare


### PR DESCRIPTION
This PR adds a new section to the bottom of the Admin Guide that details setup instructions for the flux-accounting database and multi-factor priority plugin as well as configuration of the automatic update scripts for fairshare and job usage values.