### PR TITLE
fix list rendering and Pygments warning

### DIFF
--- a/coral.rst
+++ b/coral.rst
@@ -107,7 +107,7 @@ against a system-provided ``cuda``.
 For all systems, you can test to see if the ``hwloc`` that Flux is linked against
 is CUDA-enabled by running:
 
-.. code-block:: terminal
+.. code-block:: console
 
   $ flux start flux resource list
         STATE NNODES   NCORES    NGPUS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pygments>=2.4
 Sphinx
 sphinxcontrib-spelling
-sphinx-rtd-theme
+sphinx-rtd-theme>=0.5.2
 sphinx-copybutton


### PR DESCRIPTION
This is an attempt to fix the problems rendering bullet lists described in #104.  I couldn't reproduce it locally, and for some reason github actions aren't kicking off in my local fork, so trying this as a PR.