### PR TITLE
update mergify config and small admin guide fixes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
-pull_request_rules:
-  - name: rebase and merge when passing all checks
+queue_rules:
+  - name: default
     conditions:
       - base=master
       - status-success="docs/readthedocs.org:flux-framework"
@@ -10,8 +10,17 @@ pull_request_rules:
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]
-    actions:
-      merge:
+ 
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+   actions:
+      queue:
+        name: default
         method: merge
-        strict: smart
-        strict_method: rebase
+        update_method: rebase

--- a/adminguide.rst
+++ b/adminguide.rst
@@ -845,21 +845,21 @@ listing:
 .. code-block:: console
 
  $ flux overlay status
- 0: degraded
- └1: partial
-  └3: offline
-   └7: offline
-   └8: offline
-  └4: full
-   └9: full
-   └10: full
- └2: degraded
-  └5: full
-   └11: full
-   └12: full
-  └6: degraded
-   └13: full
-   └14: lost
+ 0 fluke62: degraded
+ ├─ 1 fluke63: full
+ │  ├─ 3 fluke65: full
+ │  │  ├─ 7 fluke70: full
+ │  │  └─ 8 fluke71: full
+ │  └─ 4 fluke67: full
+ │     ├─ 9 fluke72: full
+ │     └─ 10 fluke73: full
+ └─ 2 fluke64: degraded
+    ├─ 5 fluke68: full
+    │  ├─ 11 fluke74: full
+    │  └─ 12 fluke75: full
+    └─ 6 fluke69: degraded
+       ├─ 13 fluke76: full
+       └─ 14 fluke77: lost
 
 To determine if a broker is reachable from the current rank, use:
 

--- a/adminguide.rst
+++ b/adminguide.rst
@@ -472,7 +472,7 @@ currently requires three steps
 
     .. code-block:: toml
 
-       # /etc/flux/imp/imp.toml
+       # /etc/flux/imp/conf.d/imp.toml
 
        [run.prolog]
        allowed-users = [ "flux" ]


### PR DESCRIPTION
This is a small collection of fixes:

 * update mergify config to use queues since strict merge is no longer supported
 * Fix an incorrect path to imp config in admin guide
 * update output of `flux overlay status` in admin guide (this one may be premature, but I went ahead and updated output while I was thinking about it) Happy to drop this one for now.