### PR TITLE
adminguide: update flux-core version references, clarify prolog/epilog documentation

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -13,13 +13,13 @@ resource manager on a cluster.
     in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-core
-    version 0.32.0.
+    version 0.33.0.
 
 .. warning::
-    0.32.0 limitation: the flux system instance is primarily tested on
+    0.33.0 limitation: the flux system instance is primarily tested on
     a 128 node cluster.
 
-    0.32.0 limitation: Avoid powering off nodes that are running Flux
+    0.33.0 limitation: Avoid powering off nodes that are running Flux
     without following the recommended shutdown procedure below.  Cluster
     nodes that may require service or have connectivity issues should be
     omitted from the Flux configuration for now.
@@ -254,7 +254,7 @@ Do this once and then copy the certificate to the same location on
 the other nodes, preserving owner and mode.
 
 .. warning::
-    0.32.0 limitation: the system instance tree based overlay network
+    0.33.0 limitation: the system instance tree based overlay network
     is forced by the systemd unit file to be *flat* (no interior router
     nodes), trading scalability for reliability.
 
@@ -290,7 +290,7 @@ preferably local.  Therefore, rank 0 ideally will be placed on a non-compute
 node along with other critical cluster services.
 
 .. warning::
-    0.32.0 limitation: Flux should be completely shut down when the
+    0.33.0 limitation: Flux should be completely shut down when the
     overlay network configuration is modified.
 
 Resources
@@ -355,13 +355,13 @@ This space should be preserved across a reboot as it contains the Flux
 job queue and record of past jobs.
 
 .. warning::
-    0.32.0 limitation: tools for shrinking the content.sqlite file or
+    0.33.0 limitation: tools for shrinking the content.sqlite file or
     purging old job data while retaining other content are not yet available.
 
-    0.32.0 limitation: Flux must be completely stopped to relocate or remove
+    0.33.0 limitation: Flux must be completely stopped to relocate or remove
     the content.sqlite file.
 
-    0.32.0 limitation: Running out of space is not handled gracefully.
+    0.33.0 limitation: Running out of space is not handled gracefully.
     If this happens it is best to stop Flux, remove the content.sqlite file,
     and restart.
 
@@ -455,7 +455,7 @@ Job prolog/epilog
 =================
 
 .. warning::
-    0.32.0 limitation: Flux does not yet support a traditional job prolog
+    0.33.0 limitation: Flux does not yet support a traditional job prolog
     and epilog that runs on each node before and after job tasks are executed.
     Flux does support a "job-manager" prolog and epilog, which are run on rank 0
     at the same points in a job life cycle, described below.
@@ -589,7 +589,7 @@ at the time of the next job execution, since these components are executed
 at job launch.
 
 .. warning::
-    0.32.0 limitation: all configuration changes except resource exclusion
+    0.33.0 limitation: all configuration changes except resource exclusion
     and instance access have no effect until the Flux broker restarts.
 
 Viewing resource status
@@ -798,7 +798,7 @@ combinations.
     the instance.  The version is currently required to match exactly.
 
 .. warning::
-    0.32.0 limitation: job data should be purged when updating to the
+    0.33.0 limitation: job data should be purged when updating to the
     next release of flux-core, as internal representations of data written
     out to the Flux KVS and stored in the content.sqlite file are not yet
     stable.


### PR DESCRIPTION
This PR updates flux-core version refs from 0.32.0 to 0.33.0.

Also, it turns out the job prolog/epilog section was pretty confusing, so the description has been expanded somewhat in hopes of alleviating any confusion between job vs job-manager prolog/epilog,  IMP "run" support, and the `/etc/flux/system/{prolog,epilog}.d` directory. (Unsure if it is any clearer now)