### PR TITLE
mergify: fix mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,11 +15,14 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
+      - status-success="validate commits"
       - label="merge-when-passing"
       - label!="work-in-progress"
+      - "approved-reviews-by=@flux-framework/docs"
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
-   actions:
+      - -title~=^\[*[Ww][Ii][Pp]
+    actions:
       queue:
         name: default
         method: merge


### PR DESCRIPTION
Problem: The .mergify.yml had a line that was off by one space,
and thus could not be parsed as YAML.

Fix the invlalid YAML, also move some conditions back to
pull_request_rules.