### PR TITLE
add link, refs, and intersphinx config for flux-security

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -104,6 +104,18 @@ domainrefs = {
         'text': '%s(7)',
         'url': 'https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man7/%s.html',
     },
+    'security:man3': {
+        'text': '%s(3)',
+        'url': 'https://flux-framework.readthedocs.io/projects/flux-security/en/latest/man3/%s.html',
+    },
+    'security:man5': {
+        'text': '%s(5)',
+        'url': 'https://flux-framework.readthedocs.io/projects/flux-security/en/latest/man5/%s.html',
+    },
+    'security:man8': {
+        'text': '%s(8)',
+        'url': 'https://flux-framework.readthedocs.io/projects/flux-security/en/latest/man8/%s.html',
+    },
 }
 
 # -- Options for Intersphinx -------------------------------------------------
@@ -116,6 +128,10 @@ intersphinx_mapping = {
     ),
     "core": (
         "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/",
+        None,
+    ),
+    "security": (
+        "https://flux-framework.readthedocs.io/projects/flux-security/en/latest/",
         None,
     ),
     "workflow-examples": (

--- a/index.rst
+++ b/index.rst
@@ -35,6 +35,7 @@ The framework consists of a suite of projects, tools, and libraries which may be
    :hidden:
 
    flux-core <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/index.html>
+   flux-security <https://flux-framework.readthedocs.io/projects/flux-security/en/latest/index.html>
    RFCs <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/index.html>
    Workflow Examples <https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/index.html>
 
@@ -58,6 +59,7 @@ Manual Pages
 ------------
 
 - :ref:`core:man-pages`
+- :ref:`security:man-pages`
 
 
 Workflow Examples


### PR DESCRIPTION
This PR adds a link to the new flux-security man pages, as well other configuration bits to make reference flux-security docs possible in this high-level documentation repo.