### PR TITLE
add flux-sched links to main readthedocs site

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -104,6 +104,10 @@ domainrefs = {
         'text': '%s(7)',
         'url': 'https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man7/%s.html',
     },
+    'sched:man5': {
+        'text': '%s(5)',
+        'url': 'https://flux-framework.readthedocs.io/projects/flux-sched/en/latest/man5/%s.html',
+    },
     'security:man3': {
         'text': '%s(3)',
         'url': 'https://flux-framework.readthedocs.io/projects/flux-security/en/latest/man3/%s.html',
@@ -128,6 +132,10 @@ intersphinx_mapping = {
     ),
     "core": (
         "https://flux-framework.readthedocs.io/projects/flux-core/en/latest/",
+        None,
+    ),
+    "sched": (
+        "https://flux-framework.readthedocs.io/projects/flux-sched/en/latest/",
         None,
     ),
     "security": (

--- a/index.rst
+++ b/index.rst
@@ -35,6 +35,7 @@ The framework consists of a suite of projects, tools, and libraries which may be
    :hidden:
 
    flux-core <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/index.html>
+   flux-sched <https://flux-framework.readthedocs.io/projects/flux-sched/en/latest/index.html>
    flux-security <https://flux-framework.readthedocs.io/projects/flux-security/en/latest/index.html>
    RFCs <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/index.html>
    Workflow Examples <https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/index.html>
@@ -59,6 +60,7 @@ Manual Pages
 ------------
 
 - :ref:`core:man-pages`
+- :ref:`sched:man-pages`
 - :ref:`security:man-pages`
 
 


### PR DESCRIPTION
This PR simply adds some links from our top-level docs to the newly added stub for flux-sched/fluxion documentation.