### PR TITLE
adminguide: fix [archive] TOML example

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -449,8 +449,8 @@ The ``job-archive`` module must be configured to run periodically:
 
  [archive]
  dbpath = "/var/lib/flux/job-archive.sqlite"
- period = 60
- busytimeout = 50
+ period = "1m"
+ busytimeout = "50s"
 
 The scripts should be run by :core:man1:`flux-cron`:
 


### PR DESCRIPTION
Problem: the [archive] configuration example uses integer seconds where FSD is required.

Update example.

This was noted in flux-framework/flux-core#4163.