### PR TITLE
adminguide: updates for v0.40.0

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -13,10 +13,10 @@ resource manager on a cluster.
     in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-core
-    version 0.39.0.
+    version 0.40.0.
 
 .. warning::
-    0.39.0 limitation: the flux system instance is primarily tested on
+    0.40.0 limitation: the flux system instance is primarily tested on
     a 128 node cluster.
 
 
@@ -317,7 +317,7 @@ enabled.
 Adding Job Prolog/Epilog Scripts
 ================================
 
-As of 0.39.0, Flux does not support a traditional job prolog/epilog
+As of 0.40.0, Flux does not support a traditional job prolog/epilog
 which runs as root on the nodes assigned to a job before/after job
 execution. Flux does, however, support a job-manager prolog/epilog,
 which is run at the same point on rank 0 as the instance
@@ -618,7 +618,7 @@ at the time of the next job execution, since these components are executed
 at job launch.
 
 .. warning::
-    0.39.0 limitation: most configuration changes have no effect until the
+    0.40.0 limitation: most configuration changes have no effect until the
     Flux broker restarts.  This should be assumed unless otherwise noted.
     See :core:man5:`flux-config` for more information.
 

--- a/coral.rst
+++ b/coral.rst
@@ -59,7 +59,7 @@ resources are available to Flux for scheduling.
   If you are using the ``pmi-shim`` module mentioned above, you will need to set
   ``PMIX_MCA_gds="^ds12,ds21"`` in your environment before calling ``jsrun``. The
   ``PMIX_MCA_gds`` environment variable works around `a bug in OpenPMIx
-  <https://github.com/openpmix/openpmix/issues/1396>`_ that causes a hang when
+  <https://github.com/openpmix/pmi-shim/issues/3>`_ that causes a hang when
   using the PMI compatibility shim.
 
 .. _coral_spectrum_mpi:


### PR DESCRIPTION
This PR updates the admin guide for flux-core v0.40.0.

I haven't read through the guide for any other updates, but simply updated 0.39.0 to 0.40.0.

Others should feel free to push directly here if they find any other updates that need to be made.