### PR TITLE
faqs: remove hyperlink to `flux-tree`, reference `flux-mini` instead

### DIFF
--- a/faqs.rst
+++ b/faqs.rst
@@ -54,7 +54,11 @@ How do I efficiently launch a large number of jobs to Flux?
 ------------------------------------------------------------
 
 See `bulksubmit.py <https://github.com/flux-framework/flux-workflow-examples/tree/master/async-bulk-job-submit>`_
-for an example workflow or flux `tree <https://github.com/flux-framework/flux-sched/blob/master/src/cmd/flux-tree>`_.
+for an example workflow. You can also submit many copies of the same job using
+``flux mini submit --cc=IDSET``, or submit many jobs based on a series of
+inputs on ``stdin`` or the command line via ``flux mini bulksubmit``. See the
+`flux-mini <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man1/flux-mini.html#bulksubmit>`_
+manual page for more details.
 
 .. _node_memory_exhaustion:
 


### PR DESCRIPTION
#### Problem

The hyperlink to flux-tree no longer works on the FAQ page after flux-framework/flux-sched#956, which moved `flux-tree` to the test suite and changed paths in the repo. 

---

This PR removes the hyperlink to the `flux-tree` source code since it is not available except in the source repo, and instead makes mention of `flux mini submit` and `flux mini bulksubmit`. It also adds a hyperlink to the `flux-mini` manual page.

Fixes #151 