### PR TITLE
adminguide: add [ingest] table to example config

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -280,6 +280,10 @@ Example file installed path: ``/etc/flux/system/conf.d/system.toml``
  [kvs]
  checkpoint-period = "30m"
 
+ # Immediately reject jobs with invalid jobspec or unsatisfiable resources
+ [ingest.validator]
+ plugins = [ "jobspec", "feasibility" ]
+
  # Remove inactive jobs from the KVS after one week.
  [job-manager]
  inactive-age-limit = "7d"


### PR DESCRIPTION
Problem: the example flux system configuration does not
call the feasibility validator plugin, so jobs with unsatisfiable
resource requests are terminated with an exception rather than
being rejected at submit time.

Add [ingest] to the example.