### PR TITLE
flux-accounting guide: add citation to Slurm

### DIFF
--- a/flux-accounting-guide.rst
+++ b/flux-accounting-guide.rst
@@ -148,4 +148,17 @@ association
 bank
   An account that contains associations.
 
+
+.. note::
+
+ The design of flux-accounting was driven by LLNL site requirements. Years ago,
+ the design of `Slurm accounting`_ and its `multi-factor priority
+ plugin`_ were driven by similar LLNL site requirements. We chose to
+ reuse terminology and concepts from Slurm to facilitate a smooth transition to
+ Flux. The flux-accounting code base is all completely new, however.
+
 .. _documentation: https://sqlite.org/omitted.html
+
+.. _Slurm accounting: https://slurm.schedmd.com/accounting.html
+
+.. _multi-factor priority plugin: https://slurm.schedmd.com/priority_multifactor.html


### PR DESCRIPTION
#### Background

While working on #150, a suggestion was made to add a brief citation to explain the need for adopting similar terms to Slurm's open source accounting docs in order to meet local management requirements.

---

This PR adds a notice about the similarities in both terms and concepts between flux-accounting and Slurm at the bottom of the guide, with links to both the Slurm documentation as well as the GNU General Public License documentation.

Fixes #160