### PR TITLE
adminguide: add reminder to update DB after flux-accounting version upgrade

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -567,6 +567,16 @@ See also: :core:man5:`flux-config-job-manager`.
 Automatic Accounting Database Updates
 =====================================
 
+If updating flux-accounting to a newer version on a system where a
+flux-accounting DB is already configured and set up, it is important to update
+the database schema, as tables and columns may have been added or removed in
+the newer version. The flux-accounting database schema can be updated with the
+following command:
+
+.. code-block:: console
+
+ $ flux account-update-db
+
 A series of actions should run periodically to keep the accounting
 system in sync with Flux:
 


### PR DESCRIPTION
This PR adds a reminder in the Flux Accounting section in the Administrator's Guide to update the database on a system after upgrading to a newer version of flux-accounting where a DB already exists, as tables and columns could be added or removed when moving to a newer version.