### PR TITLE
move accounting section of admin guide into accounting guide

### DIFF
--- a/flux-accounting-guide.rst
+++ b/flux-accounting-guide.rst
@@ -6,10 +6,6 @@ Flux Accounting Guide
 
 *key terms: association, bank*
 
-The *Flux Accounting Administrator's Guide* documents relevant information for
-the administration and management of flux-accounting components alongside a
-system instance install of Flux.
-
 .. note::
     flux-accounting is still beta software and many of the interfaces
     documented in this guide may change with regularity.
@@ -46,6 +42,113 @@ node, co-located with the rank 0 Flux broker, managing accounts for that
 cluster only.  Sites would typically populate the database and keep it up to
 date automatically using information regularly pulled or pushed from an
 external source like an identity management system.
+
+******************************
+Installation and Configuration
+******************************
+
+System Prerequisites
+====================
+
+The :ref:`admin-guide` documents relevant information for
+the administration and management of a Flux system instance.
+
+The following instructions assume that Flux is configured and working, that
+the Flux *statedir* (``/var/lib/flux``) is writable by the ``flux`` user,
+and that the ``flux`` user is the system instance owner.
+
+Installing Software Packages
+============================
+
+The ``flux-accounting`` package should be installed on the management node
+from your Linux distribution package manager.
+
+Accounting Database Creation
+============================
+
+The accounting database is created with the command below.  Default
+parameters are assumed, including the accounting database path of
+``/var/lib/flux/FluxAccounting.db``.
+
+.. code-block:: console
+
+ $ sudo -u flux flux account create-db
+
+.. note::
+    The flux accounting commands should always be run as the flux user. If they
+    are run as root, some commands that rewrite the database could change the
+    owner to root, causing flux-accounting scripts run from flux cron to fail.
+
+Banks must be added to the system, for example:
+
+.. code-block:: console
+
+ $ sudo -u flux flux account add-bank root 1
+ $ sudo -u flux flux account add-bank --parent-bank=root sub_bank_A 1
+
+Users that are permitted to run on the system must be assigned banks,
+for example:
+
+.. code-block:: console
+
+ $ sudo -u flux flux account add-user --username=user1234 --bank=sub_bank_A
+
+Enabling Multi-factor Priority
+==============================
+
+When flux-accounting is installed, the job manager uses a multi-factor
+priority plugin to calculate job priorities.  The Flux system instance must
+configure the ``job-manager`` to load this plugin.
+
+.. code-block:: toml
+
+ [job-manager]
+ plugins = [
+   { load = "mf_priority.so" },
+ ]
+
+See also: :core:man5:`flux-config-job-manager`.
+
+Automatic Accounting Database Updates
+=====================================
+
+If updating flux-accounting to a newer version on a system where a
+flux-accounting DB is already configured and set up, it is important to update
+the database schema, as tables and columns may have been added or removed in
+the newer version. The flux-accounting database schema can be updated with the
+following command:
+
+.. code-block:: console
+
+ $ sudo -u flux flux account-update-db
+
+A series of actions should run periodically to keep the accounting
+system in sync with Flux:
+
+- The job-archive module scans inactive jobs and dumps them to a sqlite
+  database.
+- A script reads the archive database and updates the job usage data in the
+  accounting database.
+- A script updates the per-user fair share factors in the accounting database.
+- A script pushes updated factors to the multi-factor priority plugin.
+
+The Flux system instance must configure the ``job-archive`` module to run
+periodically:
+
+.. code-block:: toml
+
+ [archive]
+ period = "1m"
+
+See also: :core:man5:`flux-config-archive`.
+
+The scripts should be run by :core:man1:`flux-cron`:
+
+.. code-block:: console
+
+ # /etc/flux/system/cron.d/accounting
+
+ 30 * * * * bash -c "flux account update-usage --job-archive_db_path=/var/lib/flux/job-archive.sqlite; flux account-update-fshare; flux account-priority-update"
 
 ***********************
 Database Administration

--- a/flux-accounting-guide.rst
+++ b/flux-accounting-guide.rst
@@ -11,7 +11,7 @@ the administration and management of flux-accounting components alongside a
 system instance install of Flux.
 
 .. note::
-    flux-accounting is still beta software and many of the interfaces 
+    flux-accounting is still beta software and many of the interfaces
     documented in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-accounting
@@ -29,15 +29,15 @@ database works with flux-core to calculate job priorities submitted by users,
 enforce basic job accounting limits, and calculate fair-share values for
 users based on previous job usage.
 
-Each user belongs to at least one bank. This user/bank combination is known 
-as an *association*, and henceforth will be referred to as an *association* 
-throughout the rest of this document.  
+Each user belongs to at least one bank. This user/bank combination is known
+as an *association*, and henceforth will be referred to as an *association*
+throughout the rest of this document.
 
 .. note::
     In order to interact with the flux-accounting database, you must have read
     and write permissions to the directory that the database resides in. The
     SQLite documentation_ states that since "SQLite reads and writes an ordinary
-    disk file, the only access permissions that can be applied are the normal 
+    disk file, the only access permissions that can be applied are the normal
     file access permissions of the underlying operating system."
 
 The front-end commands provided by flux-accounting allow an administrator to
@@ -60,7 +60,7 @@ consists of the following tables:
 +--------------------------+--------------------------------------------------+
 
 To view all associations in a flux-accounting database, the ``flux
-account-shares`` command will print this DB information in a hierarchical 
+account-shares`` command will print this DB information in a hierarchical
 format. An example is shown below:
 
 .. code-block:: console

--- a/flux-accounting-guide.rst
+++ b/flux-accounting-guide.rst
@@ -17,6 +17,36 @@ system instance install of Flux.
     This document is in DRAFT form and currently applies to flux-accounting
     version 0.18.1.
 
+********
+Overview
+********
+
+By default, a Flux system instance treats users equally and schedules work
+based on demand, without consideration of a user's history of resource
+consumption, or what share of available resources their organization considers
+they should be entitled to use relative to other competing users.
+
+Flux-accounting adds a database which stores site policy, *banks* with
+with user/project associations, and metrics representing historical usage.
+It also adds a Flux jobtap plugin that sets the priority on each job that
+enters the system based on multiple factors including *fair share* values.
+The priority determines the order in which jobs are considered by the scheduler
+for resource allocation.  In addition, the jobtap plugin holds or rejects job
+requests that exceed user/project specific limits or have exhausted their
+bank allocations.
+
+The database is populated and queried with command line tools prefixed with
+``flux account``.  Accounting scripts are run regularly by
+:core:man1:`flux-cron` to pull historical job information from the Flux
+``job-archive`` database to the accounting database, and to push bank and limit
+data to the jobtap plugin.
+
+At this time, the database is expected to be installed on a cluster management
+node, co-located with the rank 0 Flux broker, managing accounts for that
+cluster only.  Sites would typically populate the database and keep it up to
+date automatically using information regularly pulled or pushed from an
+external source like an identity management system.
+
 ***********************
 Database Administration
 ***********************


### PR DESCRIPTION
Tell me what you think about this @cmoussa1.  I thought it might be better to have all the accounting information in one manual rather than splitting it between the admin guide and the accounting guide, so this consolidates it in the accounting guide. This also adds an intro section which seemed necessary to establish some context.

(Please read the intro carefully and make sure I'm not misrepresenting the project or misusing the terminology!)