### PR TITLE
adminguide: add a blurb about core dumps

### DIFF
--- a/adminguide.rst
+++ b/adminguide.rst
@@ -272,6 +272,26 @@ Flux uses `hwloc <https://www.open-mpi.org/projects/hwloc/>`_ to verify that
 configured resources are present on nodes.  Ensure that the system installed
 version includes any plugins needed for the hardware, especially GPUs.
 
+A Word about Core Dumps
+-----------------------
+
+It is helpful to enable core dumps from the system instance ``flux-broker``
+(especially rank 0) so that useful bug reports can be filed should the broker
+crash.  Usually :linux:man8:`systemd-coredump` handles this, which makes core
+files and stack traces accessible with :linux:man1:`coredumpctl`.
+
+Some sites choose instead to configure the ``kernel.core_pattern``
+:linux:man8:`sysctl` parameter to a relative file path, which directs core
+files to the program's current working directory.  Please note that the system
+instance broker runs as the ``flux`` user with a working directory of ``/``
+and thus would not have write permission on its current working directory.
+
+.. note::
+  If you do observe a ``flux-broker`` crash, please open a github issue at
+  https://github.com/flux-framework/flux-core/issues and include the Flux
+  version, relevant log messages from ``journalctl -u flux``, and a stack
+  trace, if available.
+
 Installing Software Packages
 ============================
 

--- a/conf.py
+++ b/conf.py
@@ -88,6 +88,10 @@ domainrefs = {
         'text': '%s(7)',
         'url': 'http://man7.org/linux/man-pages/man7/%s.7.html',
     },
+    'linux:man8': {
+        'text': '%s(8)',
+        'url': 'http://man7.org/linux/man-pages/man8/%s.8.html',
+    },
     'core:man1': {
         'text': '%s(1)',
         'url': 'https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man1/%s.html',

--- a/spell.en.pws
+++ b/spell.en.pws
@@ -510,3 +510,6 @@ jobtap
 frobnicator
 globbing
 pam
+coredumpctl
+sysctl
+coredump


### PR DESCRIPTION
Problem: we really want people to capture stack traces if the rank 0 broker crashes, but the admin guide says nothing about configuring a system to capture core dumps.

Add a System Prerequisites subsection that talks about core capture and a note about reporting broker crashes.