### PR TITLE
tutorials: add pointer to "flux job attach"

### DIFF
--- a/tutorials/commands/flux-mini-submit.rst
+++ b/tutorials/commands/flux-mini-submit.rst
@@ -41,6 +41,9 @@ the status of your running jobs with ``flux jobs``:
     ƒSUEFPDH  fluxuser my_other_s  R      1      1   1.842s
     ƒM5k8m7m  fluxuser my_compute  R      4      2   3.255s
 
+If you wish to see the stdout/stderr of a submitted job, see :core:man1:`flux-job` for
+information on ``flux job attach``.
+
 -----------------------
 Interactively Run a Job
 -----------------------


### PR DESCRIPTION
Problem: In the flux mini submit tutorial, there is no information on how to view stdout/stderr of a job.

Add a pointer for users to go to "flux job attach" for more information.

----

Note, for after https://github.com/flux-framework/flux-core/pull/4936 is merged