### PR TITLE
deprecate flux-mini

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -192,7 +192,8 @@ throughout the various guides and docs on our sites.
 
 **Shell Plugins**
   Extensions of a job's environment that can be configured on a per-job basis
-  using the ``--setopt`` option of the :core:man1:`flux-mini` commands.
+  using the ``--setopt`` option of :core:man1:`flux-run` and related
+  job submission commands.
 
 .. _single-user-mode:
 

--- a/guides/admin-guide.rst
+++ b/guides/admin-guide.rst
@@ -103,8 +103,8 @@ shell plugins
   When a job is started, the :core:man1:`flux-shell` is the process parent
   of job tasks on each node.  Shell plugins extend the job environment and
   can be configured on a per-job basis using the ``--setopt`` option of
-  the :core:man1:`flux-mini` commands.  ``affinity``, ``pmi``, and ``pty``
-  are examples of Flux shell plugins.
+  :core:man1:`flux-run` and related job submission commands.  ``affinity``,
+  ``pmi``, and ``pty`` are examples of Flux shell plugins.
 
 connectors
   Flux commands open a connection to a particular Flux instance by specifying
@@ -702,14 +702,14 @@ considered for scheduling.
 
 The ``require-instance`` plugin rejects jobs that do not start another
 instance of Flux. That is, jobs are required to be submitted via tools
-like ``flux mini batch`` and ``flux mini alloc``, or the equivalent.
-For example, with this plugin enabled, a user running ``flux mini run``
+like :core:man1:`flux-batch` and :core:man1:`flux-alloc`, or the equivalent.
+For example, with this plugin enabled, a user running :core:man1:`flux-run`
 will have their job rejected with the message:
 
 .. code-block:: console
 
-  $ flux mini run -n 1000 myapp
-  flux-mini: ERROR: [Errno 22] Direct job submission is disabled for this instance. Please use the batch or alloc subcommands of flux-mini(1)
+  $ flux run -n 1000 myapp
+  flux-run: ERROR: [Errno 22] Direct job submission is disabled for this instance. Please use the flux-batch(1) or flux-alloc(1) commands.
 
 See also: :core:man5:`flux-config-ingest`.
 

--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -42,7 +42,7 @@ Mini Batch Command
 ------------------
 
 The high-level Flux command that users can use to submit a
-batch script is ``flux mini batch``.
+batch script is ``flux batch``.
 
 ``sleep_batch.sh``:
 
@@ -57,22 +57,22 @@ batch script is ``flux mini batch``.
   echo "Use sleep to emulate a parallel program"
   echo "Run the program at a total of 4 processes each requiring"
   echo "1 core. These processes are equally spread across 2 nodes."
-  flux mini run -N 2 -n 4 sleep 120
-  flux mini run -N 2 -n 4 sleep 120
+  flux run -N 2 -n 4 sleep 120
+  flux run -N 2 -n 4 sleep 120
 
 The name of your batch script is ``sleep_batch.sh``.
-As shown from the ``flux mini run`` lines in this script, you can see the the
+As shown from the ``flux run`` lines in this script, you can see the the
 overall resource requirement is 4 cores equally spread
 across two nodes as the default numbers of cores assigned to each task
 (specified by the ``-n`` option) is just one.
 
-We now submit this script interactively three times using ``flux mini batch``.
+We now submit this script interactively three times using ``flux batch``.
 
 .. code-block:: console
 
-  $ flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
-  $ flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
-  $ flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  $ flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  $ flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  $ flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
 
 Users must specify the overall resource requirement of each
 job using ``--nslots``, which is the only required option, along with
@@ -91,10 +91,10 @@ and ``--nodes=<NUM OF NODES>``
    Internally, Flux will create a nested Flux instance allocated
    to the requested resources per batch job and run the batch
    script inside that nested instance. While a batch script is
-   expected to launch parallel jobs using ``flux mini run`` or
-   ``flux mini submit`` at this level, nothing prevents the
+   expected to launch parallel jobs using ``flux run`` or
+   ``flux submit`` at this level, nothing prevents the
    script from further batching other `sub-batch-jobs` using
-   the ``flux mini batch`` interface, if desired.
+   the ``flux batch`` interface, if desired.
 
 You can check the status of these batch jobs:
 
@@ -153,9 +153,9 @@ An example sbatch script:
 .. code-block:: sh
 
   #!/bin/sh
-  flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
-  flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
-  flux mini batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
+  flux batch --nslots=2 --cores-per-slot=2 --nodes=2 ./sleep_batch.sh
   flux queue drain
 
 
@@ -166,7 +166,7 @@ Blocking and Non-blocking Commands
 It is important to note that some of the Flux commands used above are
 blocking and some of them are non-blocking.
 
-Both ``flux mini submit`` and ``flux mini batch`` have `submit` semantics
+Both ``flux submit`` and ``flux batch`` have `submit` semantics
 and as such they submit a parallel program or batch script and return
 shortly after.
 To avoid the exiting of the containing script, you can use
@@ -174,7 +174,7 @@ To avoid the exiting of the containing script, you can use
 be submitted and then waits until all submitted jobs complete.
 Thus, it is recommended not to run those commands in background.
 
-By contrast, ``flux mini run`` blocks until the target program
+By contrast, ``flux run`` blocks until the target program
 completes.
 
 

--- a/jobs/debugging.rst
+++ b/jobs/debugging.rst
@@ -16,7 +16,7 @@ parallel program execution:
 
 .. code-block:: console
 
-  $ totalview --args flux mini run -N 2 -n 2 ./mpi-program
+  $ totalview --args flux run -N 2 -n 2 ./mpi-program
 
 Attaching to an already running job:
 
@@ -33,11 +33,11 @@ GUI option to select the process of this ``flux-job`` command:
 
 .. note::
   You use TotalView with the newly invoked ``flux job attach``
-  when your job has been launched via ``flux mini run`` (or ``flux mini submit``).
+  when your job has been launched via ``flux run`` (or ``flux submit``).
   This is because Flux currently does not allow TotalView
   to attach to your running code if you just attach it
-  to the ``flux mini run`` process that controls your code. For
-  performance reasons, ``flux mini run`` does not generate
+  to the ``flux run`` process that controls your code. For
+  performance reasons, ``flux run`` does not generate
   sufficient debug information when it is invoked with no tool control.
 
 Flux provides ``MPIR_partial_attach_ok`` `[1] <https://www.mpi-forum.org/docs/mpir-specification-10-11-2010.pdf>`_
@@ -56,7 +56,7 @@ your parallel program.
 Thus, a side effect of the above commands is that TotalView
 will stop Flux's own program execution each time
 a new subcommand is ``exec(3)``'ed (e.g., when ``flux`` ``exec``'s
-``flux-mini``) before your parallel program processes are spawned.
+``flux-run``) before your parallel program processes are spawned.
 This means you must manually click "Yes" whenever a stop-at-exec
 dialogue window is popped up. You do not need to stop
 it unless you are a Flux developer!
@@ -75,7 +75,7 @@ to ``totalview``. For example,
 
 .. code-block:: console
 
-  $ totalview -s tvdrc --args flux mini run -N 2 -n 2 ./mpi-program
+  $ totalview -s tvdrc --args flux run -N 2 -n 2 ./mpi-program
 
 Notice that it is designed to support not only Flux but also SLURM's
 srun and IBM JSM's jsrun commands. The ``regex`` syntax of

--- a/jobs/hierarchies.rst
+++ b/jobs/hierarchies.rst
@@ -10,8 +10,8 @@ start --test-size=1``, to a batch job running across thousands of nodes
 on a cluster, Flux provides a consistent interface to resources.
 
 These resources and the work assigned to them may then be further
-divided by running new instances of Flux as jobs via ``flux mini batch``,
-``flux mini alloc``, or ``flux mini submit ... flux start``, each of which
+divided by running new instances of Flux as jobs via ``flux batch``,
+``flux alloc``, or ``flux submit ... flux start``, each of which
 can further divide resources through more instances, and so on. Since an
 instance of Flux has its own scheduler and configuration, this can aid in
 job throughput or scheduler specialization when complex systems of jobs
@@ -67,22 +67,22 @@ available in your Flux session may differ and jobids will not match
 those in examples.
 
 Now we can initiate some test batch jobs. In Flux, batch jobs are submitted
-with the :core:man1:`flux-mini` ``flux mini batch`` command, which starts a
+with the :core:man1:`flux-batch` command, which starts a
 new Flux instance and runs the provided batch script as the *initial
 program* of the instance. When the batch script exits, the Flux instance
 shuts down and exits as well.
 
 .. code-block:: console
 
-  [s=4,d=0] $ flux mini batch -n2 --wrap flux mini submit --wait --cc=1-1000 sleep 10
+  [s=4,d=0] $ flux batch -n2 --wrap flux submit --wait --cc=1-1000 sleep 10
   ƒ9anfxdew
   [s=4,d=0] $
 
-The command above uses the ``flux mini batch`` ``--wrap`` option to wrap
+The command above uses the ``flux batch`` ``--wrap`` option to wrap
 the remainder of arguments in a ``#!/bin/sh`` script, which allows us to
 submit a one-liner batch script without creating a separate file. The batch
 script then submits 1000 copies of ``sleep`` and waits for them all to
-complete. The ``--wait`` is important here, since ``flux mini submit``
+complete. The ``--wait`` is important here, since ``flux submit``
 exits by default after all work has been submitted, and this would cause
 the batch script to exit and terminate the batch job before any work is
 complete.
@@ -106,8 +106,8 @@ that itself submits more batch work:
    :caption: batch.sh
 
    #!/bin/sh
-   flux mini batch -n2 --wrap flux mini submit --wait --cc=1-1000 sleep 10
-   flux mini submit --cc=1-1000 sleep 10
+   flux batch -n2 --wrap flux submit --wait --cc=1-1000 sleep 10
+   flux submit --cc=1-1000 sleep 10
    flux queue idle
 
 Here, the batch script ``batch.sh`` submits another batch job requesting 2
@@ -119,7 +119,7 @@ to block until the job queue is empty, meaning all work has completed.
 
 .. code-block:: console
 
-  [s=4,d=0] $ flux mini batch -n6 batch.sh
+  [s=4,d=0] $ flux batch -n6 batch.sh
   ƒByFye1Xm
   [s=4,d=0] $ flux jobs
          JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -39,7 +39,7 @@ and start a container from it:
   $ docker run -ti fluxrm/flux-sched:latest
   $ flux getattr size
   1
-  $ flux mini run printenv FLUX_JOB_ID
+  $ flux run printenv FLUX_JOB_ID
   2597498912768
 
 .. note::
@@ -215,16 +215,16 @@ a Slurm job. You will likely want to start a single broker process per node:
   srun: job 1136410 has been allocated resources
   $
 
-An interactive Flux instance can also be started under Flux with the
-:core:man1:`flux-mini` ``alloc`` subcommand:
+An interactive Flux instance can also be started under Flux with
+:core:man1:`flux-alloc`:
 
 .. code-block:: console
 
-  $ flux mini alloc -n144 -N4
+  $ flux alloc -n144 -N4
   $
 
 .. note::
-  ``flux mini alloc`` requires the ``-n, --nslots=N`` parameter, which by
+  ``flux alloc`` requires the ``-n, --nslots=N`` parameter, which by
   default will allocate 1 core per slot. The command above will request
   to allocate 144 core across 4 nodes (for example, for a system with
   36 cores)
@@ -399,24 +399,20 @@ Though individual ranks may be targeted:
   $ flux exec -r 3 flux getattr rank
   3
 
-The second method for launching and submitting jobs is a Minimal Job
-Submission Tool ``flux mini``. The "mini" tool consists of several
-subcommands useful for different job submission scenarios:
+The second method for launching work is using one of the Flux job submission
+tools:
 
- * ``flux mini run`` - interactively run jobs
- * ``flux mini submit`` - enqueue one or more jobs
- * ``flux mini batch`` - enqueue a batch script
- * ``flux mini alloc`` - allocate a new instance for interactive use
- * ``flux mini bulksubmit`` - enqueue jobs in bulk
-
-For a full description of the ``flux mini`` command, see ``flux help mini``
-or the :core:man1:`flux-mini` man page.
+ * :core:man1:`flux-run` - interactively run jobs
+ * :core:man1:`flux-submit` - enqueue one or more jobs
+ * :core:man1:`flux-batch` - enqueue a batch script
+ * :core:man1:`flux-alloc` - allocate a new instance for interactive use
+ * :core:man1:`flux-bulksubmit` - enqueue jobs in bulk
 
 * Run 4 copies of hostname.
 
 .. code-block:: console
 
-  $ flux mini run -n4 --label-io hostname
+  $ flux run -n4 --label-io hostname
   3: quartz15
   2: quartz15
   1: quartz15
@@ -426,7 +422,7 @@ or the :core:man1:`flux-mini` man page.
 
 .. code-block:: console
 
-  $ flux mini run -n128 ./hello
+  $ flux run -n128 ./hello
   completed MPI_Init in 0.944s.  There are 128 tasks
   completed first barrier
   completed MPI_Finalize
@@ -435,7 +431,7 @@ or the :core:man1:`flux-mini` man page.
 
 .. code-block:: console
 
-  $ flux mini submit -n128 ./hello
+  $ flux submit -n128 ./hello
   ƒA6oPHNjh
 
 Here, the allocated ID for the job is immediately echoed to stdout.

--- a/tutorials/commands/flux-submit.rst
+++ b/tutorials/commands/flux-submit.rst
@@ -1,5 +1,5 @@
-.. _flux-mini-submit:
-.. _flux-mini-run:
+.. _flux-submit:
+.. _flux-run:
 
 ==========================
 How to Submit Jobs in Flux
@@ -17,9 +17,9 @@ options:
 
 .. code-block:: console
 
-    $ flux mini submit --nodes=2 --ntasks=4 --cores-per-task=2 ./my_compute_script.py 120
+    $ flux submit --nodes=2 --ntasks=4 --cores-per-task=2 ./my_compute_script.py 120
     ƒM5k8m7m
-    $ flux mini submit --nodes=1 --ntasks=1 --cores-per-task=2 ./my_other_script.py 120
+    $ flux submit --nodes=1 --ntasks=1 --cores-per-task=2 ./my_other_script.py 120
     ƒSUEFPDH
 
 In the above example, we are submitting two jobs with two different sets of
@@ -29,7 +29,7 @@ for each task. In the second submission, we are asking for our job to start 1
 task on just one node with 2 cores allocated for the task.
 
 There are many different options to customize your job submission. For further
-details, please see :core:man1:`flux-mini`.
+details, please see :core:man1:`flux-submit`.
 
 A :ref:`jobid<fluid>` (e.g., ``ƒSUEFPDH``) is returned for every job submitted. You can view
 the status of your running jobs with ``flux jobs``:
@@ -49,17 +49,17 @@ Interactively Run a Job
 -----------------------
 
 If you wish to run a job interactively, e.g. see standard output as it runs, you can
-use the ``flux mini run`` command.  It is identical to ``flux mini submit`` except it
+use the ``flux run`` command.  It is identical to ``flux submit`` except it
 will handle stdio and it will block until the job has finished.  For example:
 
 .. code-block:: console
 
-    $ flux mini run bash -c "echo start; sleep 5; echo done"
+    $ flux run bash -c "echo start; sleep 5; echo done"
     start
     done
 
 In the above example, we run a small bash script that will output "start", sleep for 5 seconds,
-and then echo "done".  Unlike ``flux mini submit``, you'll notice it does not output a jobid.
+and then echo "done".  Unlike ``flux submit``, you'll notice it does not output a jobid.
 If we check for the status of this job with ``flux jobs`` after it has run, you will not find the
 job listed because it is no longer running.  Instead run ``flux jobs -a`` which will list all jobs,
 including completed jobs.
@@ -82,14 +82,14 @@ More Examples of Submitting Flux Jobs
 
 .. code-block:: console
 
-    $ flux mini submit --nodes=2 --queue=foo --name=my_special_job ./my_job.py
+    $ flux submit --nodes=2 --queue=foo --name=my_special_job ./my_job.py
 
 This submits a job to the `foo` queue across two nodes, and sets a custom name
 to the job.
 
 .. code-block:: console
 
-    $ flux mini submit --dry-run ./my_cool_job.py
+    $ flux submit --dry-run ./my_cool_job.py
 
 If you don't want your job to actually run, but you are interested in looking
 at the :ref:`jobspec<jobspec>` for your job, include the ``--dry-run`` option
@@ -97,7 +97,7 @@ when you submit your job.
 
 .. code-block:: console
 
-    $ flux mini submit --output=job-{{id}}.out ./my_super_cool_job.py
+    $ flux submit --output=job-{{id}}.out ./my_super_cool_job.py
     ƒ3D78hc3q
 
 If you want to bypass the :ref:`KVS<kvs>` and specify a filename for STDOUT redirection,

--- a/tutorials/commands/index.rst
+++ b/tutorials/commands/index.rst
@@ -6,7 +6,7 @@ Command Tutorials
 Welcome to the Command Tutorials! These tutorials should help you to map specific Flux commands
 with your use case, and then see detailed usage. 
 
- - ``flux mini submit/flux mini run`` (:ref:`flux-mini-submit`): "Submit a job in a Flux instance"
+ - ``flux submit/flux run`` (:ref:`flux-submit`): "Submit a job in a Flux instance"
  - ``flux proxy`` (:ref:`ssh-across-clusters`): "Send commands to a Flux instance across clusters using ssh"
 
 This section is currently 🚧️ under construction 🚧️, so please come back later to see more command tutorials!
@@ -16,5 +16,5 @@ This section is currently 🚧️ under construction 🚧️, so please come bac
    :maxdepth: 2
    :caption: Command Tutorials
 
-   flux-mini-submit
+   flux-submit
    ssh-across-clusters

--- a/tutorials/commands/ssh-across-clusters.rst
+++ b/tutorials/commands/ssh-across-clusters.rst
@@ -27,7 +27,7 @@ Let's run a simple job on our allocation. This first example will ask to see the
 
 .. code-block:: console
 
-    noodle:~$ flux mini run -N 4 hostname
+    noodle:~$ flux run -N 4 hostname
     noodle220
     noodle221
     noodle222
@@ -112,7 +112,7 @@ but from the second.
 
 .. code-block:: console
 
-    quartz:~$ flux mini run hostname
+    quartz:~$ flux run hostname
     noodle220
 
 If you are still connected to the first, you should also be able to query the jobs.
@@ -120,7 +120,7 @@ E.g., here we submit a sleep from the second connected cluster:
 
 .. code-block:: console
 
-    quartz:~$ flux mini submit sleep 60
+    quartz:~$ flux submit sleep 60
     f22hdyb35
 
 And then see it from either cluster node!

--- a/tutorials/lab/coral.rst
+++ b/tutorials/lab/coral.rst
@@ -77,7 +77,7 @@ you must enable Flux's Spectrum MPI plugin.  From the CLI, this looks like:
 
 .. code-block:: sh
 
-  flux mini run -o mpi=spectrum my_mpi_binary
+  flux run -o mpi=spectrum my_mpi_binary
 
 From the Python API, this looks like::
 
@@ -121,16 +121,15 @@ is CUDA-enabled by running:
 If the number of free GPUs is 0, then the ``hwloc`` that Flux is linked against is
 not CUDA-enabled.
 
-In addition, please refer to the manual page of the
-`flux-mini(1) <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man1/flux-mini.html>`_
-command to run or to submit an MPI job with a specific CPU/GPU set
+In addition, please refer to :core:man1:`flux-run` or :core:man1:`flux-submit`
+to run or to submit an MPI job with a specific CPU/GPU set
 and affinity using its shell options.
 For example, to run a job at 4 MPI processes
 each binding to 10 CPU cores and 1 GPU on a compute node:
 
 .. code-block:: sh
 
-  flux mini run -N 1 -n 4 -c 10 -g 1 -o mpi=spectrum -o cpu-affinity=per-task -o gpu-affinity=per-task my_mpi_binary
+  flux run -N 1 -n 4 -c 10 -g 1 -o mpi=spectrum -o cpu-affinity=per-task -o gpu-affinity=per-task my_mpi_binary
 
 ----------------------------
 Launching Flux Interactively

--- a/tutorials/lab/coral2.rst
+++ b/tutorials/lab/coral2.rst
@@ -18,8 +18,8 @@ Things to Know
     Attempting to run further multi-node jobs will cause the excess jobs
     to fail. There is no limit on *submitted* multi-node jobs, and
     single-node jobs do not count towards the limit.
-#.  All nested Flux instances (e.g. instances created with ``flux mini batch``,
-    ``flux mini alloc``, or ``flux mini submit ... flux start``
+#.  All nested Flux instances (e.g. instances created with ``flux batch``,
+    ``flux alloc``, or ``flux submit ... flux start``
     should meet one of the following criteria:
 
     - Occupy a single node


### PR DESCRIPTION
Here's a batch of updates to change references to the flux-mini commands to their new names which will appear in flux-core v0.39.0.