### PR TITLE
docker dev environment fix permissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,13 @@
 FROM fluxrm/flux-sched:focal
 
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+
 LABEL maintainer="Vanessasaurus <@vsoch>"
 
 # Pip not provided in this version
@@ -16,6 +24,12 @@ RUN python3 -m pip install IPython && \
     python3 -m pip install -r /dev-requirements.txt && \
     # For developer convenience
     ln -s /usr/bin/python3 /usr/bin/python
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME
 
 ENV PATH=/env/bin:${PATH}
 WORKDIR /workspace/flux-docs


### PR DESCRIPTION
Problem: permissions are written as root in the current devcontainer
Solution: run them as the vscode user with uid/gid 1000

This is the same fix applied to the flux-core container - I also tested it out (and doing things with sudo) and it seems good!