### PR TITLE
flux-accounting guide: add setup instructions for new flux-accounting service

### DIFF
--- a/guides/accounting-guide.rst
+++ b/guides/accounting-guide.rst
@@ -11,7 +11,7 @@ Flux Accounting Guide
     documented in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-accounting
-    version 0.18.1.
+    version 0.31.0.
 
 ********
 Overview

--- a/guides/accounting-guide.rst
+++ b/guides/accounting-guide.rst
@@ -61,7 +61,27 @@ Installing Software Packages
 ============================
 
 The ``flux-accounting`` package should be installed on the management node
-from your Linux distribution package manager.
+from your Linux distribution package manager. Once installed, the service
+that accepts ``flux account`` commands and interacts with the flux-accounting
+database can be started.
+
+You can enable the service with ``systemctl``; if not configured with a custom
+path, the flux-accounting systemd unit file will be installed to the same
+location as flux-core's systemd unit file:
+
+.. code-block:: console
+
+  $ sudo systemctl enable flux-accounting
+
+The service can then be controlled with ``systemd``. To utilize the service,
+the following prerequisites must be met:
+
+1. A flux-accounting database has been created with ``flux account create-db``.
+The service establishes a connection with the database in order to read from
+and write to it.
+
+2. An active Flux system instance is running. The flux-accounting service will
+only run after the system instance is started.
 
 Accounting Database Creation
 ============================


### PR DESCRIPTION
#### Background

flux-accounting has a new service that accepts `flux account` commands that interact with the flux-accounting database and can be controlled with `systemd`, but there are no setup instructions on how to get it going in the flux-accounting guide on our docs site.

---

This PR adds a couple of small fixes along with a set of notes on installing and setting up the flux-accounting service in the flux-accounting guide. Since this new addition to documentation will be required _as a result of_ the new flux-accounting release coming up in a few days, I will leave this is as [WIP] until the release has been finalized. Feel free to take a look at my changes proposed here in the meantime, though, in case there is any feedback. 👍

Fixes #215