### PR TITLE
add docker-compose container tutorials

### DIFF
--- a/tutorials/containers/index.rst
+++ b/tutorials/containers/index.rst
@@ -6,7 +6,7 @@ Container Tutorials
 These are "quick start" container tutorials to get you up-and-running Flux in no time!
 
  - ``fluxrm/flux-sched:focal``: :ref:`flux-sched-container`
- - ``flux with docker-compose``: 🥑️ *coming soon* 🥑️
+ - ``flux with docker-compose``: Tutorials for `replicated and manual specified strategies <https://github.com/rse-ops/flux-compose/>`_
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
These tutorials come with a lot of supporting files and context, so I think it makes sense to reference them instead of duplicating, that way people can open issues there, request more examples, easily clone to get started and we don't need to update in two places.

I added a cleaned up "replicas" example this morning.