### PR TITLE
fix bug with check_diff.py sys import missing

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -8,6 +8,7 @@
 import argparse
 import os
 import fnmatch
+import sys
 
 
 def recursive_find(base, pattern="*.*"):

--- a/auto_examples/index.rst
+++ b/auto_examples/index.rst
@@ -30,7 +30,7 @@ of using the Flux Python API.
 .. only:: html
 
   .. image:: /auto_examples/images/thumb/sphx_glr_example_job_submit_api_thumb.png
-    :alt: Introductory example - Job Submit API
+    :alt:
 
   :ref:`sphx_glr_auto_examples_example_job_submit_api.py`
 


### PR DESCRIPTION
I think @chu11's simple PR failed because we are missing the sys import! Let's get this change in.