### PR TITLE
expose flux comparison table

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -37,6 +37,13 @@ The framework consists of a suite of projects, tools, and libraries which may be
 
    projects
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Comparison Table
+
+   tables/comparison-table
+
+
 Contributor Relevant RFCs
 -------------------------
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -4,8 +4,8 @@
 Quick Start
 ============
 
-A quick introduction to Flux and flux-core. For reference, the :ref:`Glossary`
-contains definitions for a number of terms, Flux-specific concepts, and
+A quick introduction to Flux and flux-core. If you are looking to see how Flux compares to your favorite resource manager, see :ref:`comparison-table`.
+For reference, the :ref:`Glossary` contains definitions for a number of terms, Flux-specific concepts, and
 acronyms mentioned in this guide and throughout our documentation site.
 
 .. note::


### PR DESCRIPTION
Problem: the comparison table is highly useful, but hidden under a section of the FAQ and hard to find.
Solution: add it as a navigation tab on the top (the rationale that some will come to the docs explicitly looking for it) along with as a link in the first line of the quickstart.

This has been a thought lingering on my mind for a few months, and after someone in the slack had the same trouble to validate my concern, I think we want to better expose our comparison table. For this PR, I've added it exposed in two places:

1. At the very top as its own navigation heading

![image](https://user-images.githubusercontent.com/814322/234439763-3ad44aff-75f5-4ba3-82a1-2ce3b0d7acc6.png)

We aren't best using these navigation headings (we only have two!) and I think a substantial number of users coming to the site are coming explicitly to answer the question "How does this Flux tool compare to..." so it should be at the top, front and center.

2. At the top of the quick start

For really the same use case, but if the person misses the top tab and clicks Contents -> quick start first.

![image](https://user-images.githubusercontent.com/814322/234439885-93e3451c-8e90-4da4-84f7-043155e44a02.png)

That said - I'm not sure "Contents" is super meaningful - it's definitely correct but I wonder if there is a better term?