### PR TITLE
Rabbit usage documentation

### DIFF
--- a/tutorials/lab/coral2.rst
+++ b/tutorials/lab/coral2.rst
@@ -78,3 +78,24 @@ The lines should come before any call to load plugins.
 
 If Flux jobs that use Cray MPICH end up as a collection of singletons,
 that is usually a sign that Cray MPICH is trying to use libPALS.
+
+-----------------------------
+Configuring Flux with Rabbits
+-----------------------------
+
+In order for a Flux system instance to be able to allocate
+rabbit storage, the ``dws_jobtap.so`` plugin must be loaded.
+The plugin can be loaded in a  config file like so:
+
+.. code-block::
+
+    [job-manager]
+    plugins = [
+      { load = "dws-jobtap.so" }
+    ]
+
+Also, the ``flux-coral2-dws`` systemd service must be started
+on the same node as the rank 0 broker of the system instance
+(i.e. the management node). The ``flux`` user must have
+a kubeconfig file in its home directory granting it read
+and write access.

--- a/tutorials/lab/coral2.rst
+++ b/tutorials/lab/coral2.rst
@@ -1,13 +1,13 @@
 .. _coral2:
 
-==================================
-CORAL2: Native Flux on Cray Shasta
-==================================
+===========================
+CORAL2: Flux on Cray Shasta
+===========================
 
-The LLNL, LBNL, and ORNL next-generation systems like RZNevada, Perlmutter,
-El Capitan, and Frontier are in various stages of early access. They are
-similar in that they all use the HPE Cray Shasta platform, which requires
-a few additional components to integrate completely with Flux.
+The LLNL, LBNL, and ORNL systems like Tioga, Perlmutter,
+El Capitan, and Frontier are similar in that they all use the
+HPE Cray Shasta platform, which requires
+an additional component to integrate completely with Flux.
 
 --------------
 Things to Know
@@ -18,9 +18,7 @@ Things to Know
     Attempting to run further multi-node jobs will cause the excess jobs
     to fail. There is no limit on *submitted* multi-node jobs, and
     single-node jobs do not count towards the limit.
-#.  All nested Flux instances (e.g. instances created with ``flux batch``,
-    ``flux alloc``, or ``flux submit ... flux start``
-    should meet one of the following criteria:
+#.  All Flux instances should meet one of the following criteria:
 
     - Occupy a single node
     - Have exclusive access to the nodes they are running on (e.g. they
@@ -28,86 +26,55 @@ Things to Know
 
     Instances that do not meet one of the above criteria will not work properly.
 
+By default Flux reserves ports 11000-11999 for itself. At any given
+level of the Flux hierarchy, this can be changed by configuring Flux
+to load the `cray_pals_port_distributor` jobtap plugin with a different
+range of ports, like so:
+
+.. code-block:: toml
+
+    [job-manager]
+    plugins = [
+      { load = "cray_pals_port_distributor.so", conf = { port-min = 11000, port-max = 13000 } }
+    ]
+
 ------------------------
 Building Flux for CORAL2
 ------------------------
 
 The basic steps to building Flux for Cray Shasta systems are as follows:
 
-#.  :ref:`Build flux-core and flux-sched manually <manual_installation>`
-    with some prefix *P*.
+#.  :ref:`Build flux-core (version >= 0.49.0) and flux-sched manually
+    <manual_installation>` with some prefix *P*.
 #.  Build `flux-coral2 <https://github.com/flux-framework/flux-coral2>`_
     with the same prefix *P*.
-#.  Create a Flux config file specifying that the ``cray_pals_port_distributor.so``
-    plugin should be loaded with some given port range (see below for an example).
-    If you have other config files, put the new file in with the others.
-    Before launching Flux, point Flux to the *directory* containing your config
-    file(s) by setting the ``FLUX_CONF_DIR`` environment variable, or by passing
-    ``-o"-c/path/to/config"`` to ``flux start``.
-#.  As an alternative to creating a config file and setting ``FLUX_CONF_DIR``,
-    you can, after starting Flux, execute ``flux jobtap load
-    cray_pals_port_distributor.so port-min=$N port-max=$M`` for some *N* and *M*.
+
+------------------
+Flux with Cray PMI
+------------------
+
+Applications linked to Cray MPICH will work natively with Flux
+provided the Cray MPICH library uses the PMI2 protocol instead of
+the homespun Cray PMI and libPALS. For Flux to support libPALS,
+flux-coral2 must be built (see above) and Flux must be configured
+to offer libPALS support. This is done by setting the "pmi" shell
+option to include "cray-pals" on a per-job basis like so:
+
+.. code-block:: console
+
+    $ flux submit -n2 -opmi=cray-pals ./mpi_hello
+
+or by configuring Flux to offer such support by default, by adding
+the following lines to the shell's ``initrc.lua`` file:
+
+.. code-block:: lua
+
+    if shell.options['pmi'] == nil then
+        shell.options['pmi'] = 'cray-pals,simple'
+    end
 
 
-If you see job failures with an error message like "no cray_pals_port_distribution
-event posted", check that you have the ``cray_pals_port_distributor.so`` plugin
-loaded by running ``flux jobtap list``. If you don't see it in the list, retry
-step 3 or 4 above.
+The lines should come before any call to load plugins.
 
-A script to build Flux is below.
-
-.. code-block:: sh
-
-  #!/bin/bash
-
-  set -e
-
-  PREFIX=$HOME/local  # a good default, but modify as needed
-  PORT_MIN=11000      # a good default, but modify as needed
-  PORT_MAX=12000      # a good default, but modify as needed
-
-  # Step 1: Build flux-core 0.29 or later
-
-  wget https://github.com/flux-framework/flux-core/releases/download/v0.29.0/flux-core-0.29.0.tar.gz
-
-  tar -xzvf flux-core-0.29.0.tar.gz && cd flux-core-0.29.0
-
-  ./configure --prefix=$PREFIX && make -j && make install && cd ..
-
-  # The `flux` executable will now be in ~/local/bin/flux but it needs some
-  # additional flux-coral2 extensions
-
-
-  # Step 2: Build flux-sched 0.18 or later (optional but recommended)
-
-  wget https://github.com/flux-framework/flux-sched/releases/download/v0.18.0/flux-sched-0.18.0.tar.gz
-
-  tar -xzvf flux-sched-0.18.0.tar.gz && cd flux-sched-0.18.0
-
-  ./configure --prefix=$PREFIX && make -j && make install && cd ..
-
-
-  # Step 3: Build flux-coral2
-
-  git clone https://github.com/flux-framework/flux-coral2.git && cd flux-coral2
-
-  ./autogen.sh && ./configure --prefix=$PREFIX && make -j && make install
-
-  libtool --finish $PREFIX/lib/flux/job-manager/
-  libtool --finish $PREFIX/lib/flux/shell/plugins/
-  cd ..
-
-
-  # Step 4: add a config file to automatically load a flux-coral2 plugin
-
-  mkdir -p $PREFIX/etc/flux/config
-
-  echo "[job-manager]
-  plugins = [
-     { load = \"cray_pals_port_distributor.so\", conf = { port-min = $PORT_MIN, port-max = $PORT_MAX } }
-  ]
-  " > $PREFIX/etc/flux/config/cray_pals_ports.toml
-
-  echo "Done! Now set FLUX_CONF_DIR=$PREFIX/etc/flux/config
-  in your environment and run with $PREFIX/bin/flux"
-
+If Flux jobs that use Cray MPICH end up as a collection of singletons,
+that is usually a sign that Cray MPICH is trying to use libPALS.

--- a/tutorials/lab/index.rst
+++ b/tutorials/lab/index.rst
@@ -13,4 +13,5 @@ provided there are for collaborating systems.
    LLNL Introduction to Flux <https://hpc-tutorials.llnl.gov/flux/>
    coral
    coral2
+   rabbit
 

--- a/tutorials/lab/rabbit.rst
+++ b/tutorials/lab/rabbit.rst
@@ -1,0 +1,133 @@
+.. _rabbit:
+
+=================
+Flux with Rabbits
+=================
+
+
+How to Allocate Rabbit Storage
+------------------------------
+
+Request rabbit storage allocations for a job
+by setting the ``.attributes.system.dw`` field in a jobspec to
+a string containing one or more DW directives, or to a list of
+singleton DW directives.
+
+DW directives are strings that start with ``#DW``. Directives
+that begin with ``#DW jobdw`` are for requesting storage that
+lasts the lifetime of the associated flux job. Directives that
+begin with ``#DW copy_in`` and ``#DW copy_out`` are for
+describing data movement to and from the rabbits, respectively.
+
+The usage is most easily understood by example.
+
+
+Examples of jobdw directives
+----------------------------
+
+Requesting a 10 gigabyte XFS file system per compute node on the
+command line:
+
+.. code-block:: console
+
+	$ flux alloc -N2 --setattr=dw="#DW jobdw type=xfs capacity=10GiB name=project1"
+
+Requesting both XFS and lustre file systems in a batch script:
+
+.. code-block:: bash
+
+	#!/bin/bash
+
+	#FLUX: -N 2
+	#FLUX: -q pdebug
+	#FLUX: --setattr=dw="""
+	#FLUX: #DW jobdw type=xfs capacity=1TiB name=xfsproject
+	#FLUX: #DW jobdw type=lustre capacity=10GiB name=lustreproject
+	#FLUX: """
+
+	echo "Hello World!" > $DW_JOB_lustreproject/world.txt
+
+	flux submit -N2 -n2 /bin/bash -c "echo 'Hello World!' > $DW_JOB_xfsproject/world.txt"
+
+
+jobdw directive fields
+----------------------
+
+The **type** field can be one of ``xfs``, ``lustre``, ``gfs2``, or ``raw``.
+``lustre`` storage is shared by all nodes in the job. By contrast, the other types
+are for node-local storage. Processes on one node will not be able to read
+data written on other nodes. Currently only ``xfs`` and ``lustre`` are known
+to work properly.
+
+The **capacity** field describes how much storage to be allocated. For ``lustre``
+the capacity refers to the overall capacity. For all other types, the capacity refers
+to the capacity per node. See
+`this Wikipedia article <https://en.wikipedia.org/wiki/Byte#Multiple-byte_units>`_
+for the meaning of the suffixes.
+
+The **name** field determines the suffix to the ``DW_JOB_`` environment variable.
+See below for more detail.
+
+
+Using Rabbit Storage
+--------------------
+
+For each ``jobdw`` directive associated with your job, your job will have
+an environment variable ``DW_JOB_[name]`` where ``[name]`` is the value
+of the ``name`` field in the directive. The value of the environment variable
+will be the path to the associated file system.
+
+For instance, for a directive ``#DW jobdw type=xfs capacity=10GiB name=project1``,
+the associated job will have an environment variable ``DW_JOB_project1``.
+
+
+Data Movement Directives
+------------------------
+
+To request that files be moved to or from the rabbits, additional DW
+directives must be added to the job in addition to jobdw directives.
+The ``copy_in`` directive is for moving data to the rabbits before the job
+starts, and the ``copy_out`` directive is for moving data from the rabbits
+after the job completes.
+
+Both ``copy_in`` and ``copy_out`` directives have ``source`` and ``destination``
+fields which indicate where data is to be taken from and where it is to be moved to.
+The source must exist.
+
+
+Data Movement Examples
+----------------------
+
+.. warning::
+
+	When writing ``copy_in`` and ``copy_out`` directives *on the command line*,
+	be careful to always escape the ``$`` character when writing ``DW_JOB_[name]``
+	variables. Otherwise your shell will expand them. This warning does not apply
+	to batch scripts.
+
+Requesting a 10 gigabyte XFS file system per compute node on the command
+line with data movement both to and from the rabbits (the source directory
+is assumed to exist):
+
+.. code-block:: console
+
+	$ flux alloc -N2 --setattr=dw="#DW jobdw type=xfs capacity=10GiB name=project1
+	#DW copy_in source=/p/lustre1/$USER/dir_in destination=\$DW_JOB_project1/
+	#DW copy_out source=\$DW_JOB_project1/ destination=/p/lustre1/$USER/dir_out/"
+
+Requesting a lustre file system, with data movement out from the rabbits,
+in a batch script:
+
+.. code-block:: bash
+
+	#!/bin/bash
+
+	#FLUX: -N 2
+	#FLUX: -q pdebug
+	#FLUX: --setattr=dw="""
+	#FLUX: #DW jobdw type=lustre capacity=10GiB name=lustreproject
+	#FLUX: #DW copy_out source=$DW_JOB_lustreproject destination=/p/lustre1/$USER/lustreproject_results
+	#FLUX: """
+
+	echo "Hello World!" > $DW_JOB_lustreproject/world.txt
+


### PR DESCRIPTION
Updates and simplifies the CORAL2 documentation to remove a lot of outdated configuration information. Also adds documentation about how to use rabbits.

The CORAL2 docs I don't expect anyone to look at really, except maybe I can point some admins to it occasionally. The rabbit page I expect to be used much more frequently.