### PR TITLE
add start of language bindings

### DIFF
--- a/tutorials/bindings/index.rst
+++ b/tutorials/bindings/index.rst
@@ -1,0 +1,23 @@
+.. _language-bindings:
+
+Language Bindings
+=================
+
+We provide this set of external tutorials as complete project setups that demonstrate
+using Flux from a different language, or (TBA) natively with C. Each of these tutorial
+repositories provides:
+
+ - A set of common use case examples or snippets 🗒️
+ - A build setup for compiling the snippets 🏗️
+ - A Developer environment (e.g., VSCode Devcontainers) for easy development 🐟️
+ - Continuous integration with an automated container build and testing ⚙️
+ - A web interface that renders the most up-to-date snippets 🖼️
+
+Thus, it should be easy for you to fork or clone any repository, and get started with your
+custom project that interacts with Flux.
+
+ - ``Go Bindings``: `flux-go <https://github.com/converged-computing/flux-go/>`_
+
+These are a work in progress, and we ask you to `let us know <https://github.com/flux-framework/flux-docs/issues>`_ 
+if you have requests for examples, and please comment on the respective respositories above with 
+questions about any specific lagnuage.

--- a/tutorials/index.rst
+++ b/tutorials/index.rst
@@ -16,3 +16,4 @@ find a tutorial of interest.
    containers/index
    lab/index
    integrations/index
+   bindings/index


### PR DESCRIPTION
This is the start of a (likely multiple PR/ multiple repository) to refactor / create a set of language bindings tutorials/snippets. Importantly, each is a separate repository that (akin to what the page says) includes:

- examples and snippets
- developer environment
- build setup for compiling 
- CI with automated container build and testing
- web interface to render snippets (or for the user, they could use it for docs)

The high level goal is that a contributor developer could fork/clone one of these repos and jump in to developing their project that uses flux without having to untangle or otherwise figure out the logic from our main repos.

For the main plan, since we already have some Python here, this is my proposal. Under tutorials I think we should remove the top group that we currently have for the "Python API" and move these examples into their own repository. Then, we can link (to start) each of the external repos for C/C++, Python, and Go (and TBA others) like this:

![image](https://user-images.githubusercontent.com/814322/235322818-a9c0c0b5-c171-41c0-85da-8ceb8a6a4e8b.png)
 
I put it first there because that's where Python currently is, it doesn't need to be. 

Let me know your thoughts on this! If you like the idea, my proposal is to review/merge here, and then I can start refactoring our Python examples here to be in a separate repository, and (in the meantime) if someone else wants to make a simple repository with a src folder and Makefile for C/C++, I can add the developer environment, docs, and automation around that.