### PR TITLE
rabbit: note allowed chars in name field

### DIFF
--- a/tutorials/lab/rabbit.rst
+++ b/tutorials/lab/rabbit.rst
@@ -68,6 +68,11 @@ for the meaning of the suffixes.
 The **name** field determines the suffix to the ``DW_JOB_`` environment variable.
 See below for more detail.
 
+.. note::
+
+	The **name** field can only contain lowercase alphanumeric characters.
+	Underscores, spaces, and dashes are not allowed.
+
 
 Using Rabbit Storage
 --------------------


### PR DESCRIPTION
Problem: the allowed characters in the 'name' field of DW strings is very limited. Some users
may attempt illegal names, and the error message
they would get is unhelpful.

Add a note about the allowed characters in the
name field.