### PR TITLE
[WIP] flux-accounting guide: add instructions for setting up local job-archive

### DIFF
--- a/guides/accounting-guide.rst
+++ b/guides/accounting-guide.rst
@@ -11,7 +11,7 @@ Flux Accounting Guide
     documented in this guide may change with regularity.
 
     This document is in DRAFT form and currently applies to flux-accounting
-    version 0.18.1.
+    version 0.26.0.
 
 ********
 Overview


### PR DESCRIPTION
_note: this should be left as [WIP] until flux-framework/flux-accounting#357 has landed and a new flux-accounting release is created._

This PR looks to update the instructions for set up in the Flux Accounting Guide. Namely, it includes instructions for setting up the new Python script that fetches jobs from flux-core and places them in its own job-archive in the flux-accounting DB. It removes any mention of a need to have flux-core's job-archive module loaded and configured. It also lists the newly added tables in the flux-accounting DB.

Fixes #243