### PR TITLE
admin: add note about clock synchronization

### DIFF
--- a/guides/admin-guide.rst
+++ b/guides/admin-guide.rst
@@ -263,6 +263,9 @@ System Prerequisites
 submitted to Flux, so the MUNGE daemon should be installed on all
 nodes running Flux with the same MUNGE key used across the cluster.
 
+System clocks must be synchronized across the cluster, e.g. with
+`Network Time Protocol <https://en.wikipedia.org/wiki/Network_Time_Protocol>`_.
+
 Flux assumes a shared UID namespace across the cluster.
 
 A system user named ``flux`` is required.  This user need not have a valid

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ markupsafe==2.0.1
 # waiting on dark mode
 # sphinx_material
 sphinx-immaterial
+pydantic==1.10.8
 recommonmark
 sphinx_markdown_tables
 myst-parser


### PR DESCRIPTION
Problem: Flux requires local clocks to be synchronized across the cluster, but this is not mentioned in the Admin Guide.

For example
- job-ingest sets `t_submit` to the local time
- flux_job_timeleft() returns expiration relative to the local time
- Flux logs are time stamped at origin

Add a note to the section on prerequisites.