### PR TITLE
jobs: cleanup jobs/batch.rst

### DIFF
--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -66,11 +66,6 @@ In this example, each job requests two slots each with
 2 cores (``--cores-per-slot=2``) and these slots must be equally spread
 across two nodes (``--nodes=4``).
 
-Currently, if you want a script to be exclusively allocated to a set of
-nodes, the recommended option set is:
-``--nslots=<NUM OF NODES>`` ``--cores-per-slot=<MAX NUM OF CORES PER NODE>``
-and ``--nodes=<NUM OF NODES>``
-
 .. note::
    Internally, Flux will create a nested Flux instance allocated
    to the requested resources per batch job and run the batch

--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -21,22 +21,6 @@ more batch jobs to run further subinstances of Flux.
    but it is important to note that the same commands and techniques
    will also work at the system level.
 
-----------------------------------
-Launching Flux in Interactive Mode
-----------------------------------
-
-For this demonstration, we first launch Flux under SLURM and get an interactive shell.
-
-.. code-block:: console
-
-  $ salloc -N4 -ppdebug
-  salloc: Granted job allocation 5620626
-  $ srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --pty --mpi=none --mpibind=off flux start
-
-.. note::
-   If launching under SLURM is not possible or convenient, a single-node
-   single user instance of Flux can be started with ``flux start -s 4``.
-
 -------------
 Batch Command
 -------------

--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -36,7 +36,7 @@ batch script is ``flux batch``.
   
   echo "Starting my batch job"
   echo "Print the resources allocated to this batch job"
-  flux hwloc info
+  flux resource info
   
   echo "Use sleep to emulate a parallel program"
   echo "Run the program at a total of 4 processes each requiring"
@@ -105,7 +105,7 @@ Checking the output file of one of the batch job:
 
   $ cat flux-ƒWZEQa8X.out
   Print the resources allocated to this batch job
-  2 Machines, 4 Cores, 8 PUs
+  2 Nodes, 4 Cores, 0 GPUs
   Use sleep to emulate a parallel program
   Run the program at a total of 4 processes each requiring
   1 core. These processes are equally spread across 2 nodes.


### PR DESCRIPTION
Someone complained that when they searched "start Flux interactively" they got a reference to starting Flux under Slurm `salloc` in a section about batch jobs.

Since this didn't make much sense, I wanted to remove this section. I didn't want to go into too much cleanup here, so I just went through the `jobs.batch.rst` docs and removed erroneous or outdated information, and corrected an example.