### PR TITLE
fix: readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,12 +5,17 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+
 # Build documentation in the top-level directory with Sphinx
 sphinx:
   configuration: conf.py
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: requirements.txt


### PR DESCRIPTION
Problem: the readthedocs config is missing os
Solution: update the format.

Criteria for merge are a successful readthedocs build, since there are no other changes. This is a response to #256 where the build failed due to missing build.os key in .readthedocs.yaml.