### PR TITLE
tutorials: fix incorrect option in flux-submit tutorial

### DIFF
--- a/tutorials/commands/flux-submit.rst
+++ b/tutorials/commands/flux-submit.rst
@@ -82,7 +82,7 @@ More Examples of Submitting Flux Jobs
 
 .. code-block:: console
 
-    $ flux submit --nodes=2 --queue=foo --name=my_special_job ./my_job.py
+    $ flux submit --nodes=2 --queue=foo --job-name=my_special_job ./my_job.py
 
 This submits a job to the `foo` queue across two nodes, and sets a custom name
 to the job.


### PR DESCRIPTION
Problem: The flux-submit tutorial gives an example that uses --name to set the job name, but no such option exists.

Correct --name to --job-name.