### PR TITLE
admin-guide: clarify queue property name requirements

### DIFF
--- a/guides/admin-guide.rst
+++ b/guides/admin-guide.rst
@@ -732,8 +732,12 @@ Adding Queues
 
 It may be useful to configure a Flux system instance with multiple queues.
 Each queue should be associated with a non-overlapping resource subset,
-identified by property name.  It is good practice for queues to create a
-new property that has the same name as the queue.
+identified by property name. It is good practice for queues to create a
+new property that has the same name as the queue. (There is no requirement
+that queue properties match the queue name, but this will cause extra entries
+in the PROPERTIES column for these queues. When queue names match property
+names, :command:`flux resource list` suppresses these matching properties
+in its output.)
 
 When queues are defined, all jobs must specify a queue at submission time.
 If that is inconvenient, then ``policy.jobspec.defaults.system.queue`` may


### PR DESCRIPTION
Problem: There is a statement in the admin guide that it is good practice to use property names that match the corresponding queue name, but no reason for this practice is given.

Explain that queue properties do not need to match the queue name, but note that it is good practice because it allows flux-resource list to suppress these duplicate names in is output.