### PR TITLE
accounting-guide: update description of DB tables

### DIFF
--- a/guides/accounting-guide.rst
+++ b/guides/accounting-guide.rst
@@ -191,6 +191,12 @@ consists of the following tables:
 | t_half_life_period_table | keeps track of the current half-life period for  |
 |                          | calculating job usage factors                    |
 +--------------------------+--------------------------------------------------+
+| queue_table              | stores queues, their limits properties, as well  |
+|                          | as their associated priorities                   |
++--------------------------+--------------------------------------------------+
+| project_table            | stores projects for associations to charge their |
+|                          | jobs against                                     |
++--------------------------+--------------------------------------------------+
 
 To view all associations in a flux-accounting database, the ``flux
 account-shares`` command will print this DB information in a hierarchical


### PR DESCRIPTION
#### Problem

The flux-accounting guide has a table which lists all of the tables in the flux-accounting database, but the schema has been updated to have a couple new tables.

---

This PR updates the flux-accounting guide to include these new tables.