### PR TITLE
tutorials: make CORAL example consistent

### DIFF
--- a/auto_examples/index.rst
+++ b/auto_examples/index.rst
@@ -22,6 +22,7 @@ of using the Flux Python API.
 
     <div class="sphx-glr-thumbnails">
 
+.. thumbnail-parent-div-open
 
 .. raw:: html
 
@@ -39,6 +40,8 @@ of using the Flux Python API.
       <div class="sphx-glr-thumbnail-title">Introductory example - Job Submit API</div>
     </div>
 
+
+.. thumbnail-parent-div-close
 
 .. raw:: html
 

--- a/tutorials/lab/coral.rst
+++ b/tutorials/lab/coral.rst
@@ -165,7 +165,7 @@ When this is submitted, the system will print out a job ID. You can check the st
   ...
   [elvis@lassen709:~]$ bjobs
   JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
-  3750480    hobbs17 RUN   pdebug     lassen709   1*launch_ho fluxsesh   Jul 25 12:44
+  3750480    elvis   RUN   pdebug     lassen709   1*launch_ho fluxsesh   Jul 25 12:44
                                                   80*debug_hosts
 
 Once the job starts to run, you can resolve the URI, and connect to the session remotely.


### PR DESCRIPTION
Problem: the CORAL interactive tutorial uses the username "elvis" in all places but one.

Solution: make the document consistent by removing the last reference to "hobbs17" and replacing with "elvis".