### PR TITLE
coral2: update HPE rabbit docs link

### DIFF
--- a/tutorials/lab/rabbit.rst
+++ b/tutorials/lab/rabbit.rst
@@ -21,7 +21,7 @@ begin with ``#DW copy_in`` and ``#DW copy_out`` are for
 describing data movement to and from the rabbits, respectively.
 
 Full documentation of the DW directives and their arguments is available
-`here <https://nearnodeflash.github.io/dev/guides/user-interactions/readme/>`_.
+`here <https://nearnodeflash.github.io/latest/guides/user-interactions/readme/>`_.
 
 The usage with Flux is most easily understood by example.
 


### PR DESCRIPTION
Dumb change but pointing to 'latest' wasn't an option when #275 was merged, it only became an option when HPE published a new release two hours ago.