### PR TITLE
projects: add flux-accounting as subproject

### DIFF
--- a/projects.rst
+++ b/projects.rst
@@ -25,6 +25,12 @@ Flux Security
 
  -  Read the `flux-security documentation <https://flux-framework.readthedocs.io/projects/flux-security/en/latest/index.html>`_
 
+---------------
+Flux Accounting
+---------------
+
+ -  Read the `flux-accounting documentation <https://flux-framework.readthedocs.io/projects/flux-accounting/en/latest/index.html>`_
+
 ----
 Dyad
 ----


### PR DESCRIPTION
#### Problem

flux-accounting is not listed as a subproject on the Projects page on the flux-framework documentation site.

---

Add flux-accounting as a project and point to its documentation on ReadTheDocs.