### PR TITLE
github: add `--ignore-installed` to `pip install` of requirements 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       run: >-
           sudo apt-get update -y &&
           sudo apt-get install -y python3-pip &&
-          sudo pip3 install --upgrade -r ./requirements.txt
+          sudo pip3 install --ignore-installed --upgrade -r ./requirements.txt
 
     - name: Check Spelling
       uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0


### PR DESCRIPTION
Problem: recently, our github workflow for spelling and
linkcheck got confused between pre-installed debian packages
and python's pip installed packages.

Just ignore the debian packages. Install our own. It doesn't
seem to take much longer.

```
-I, --ignore-installed

    Ignore the installed packages, overwriting them. This can break your system if the existing package is of a different version or was installed with a different package manager!

    (environment variable: PIP_IGNORE_INSTALLED)
```
From: https://pip.pypa.io/en/stable/cli/pip_install/