### PR TITLE
faq: add entry about reslient batch jobs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -193,10 +193,6 @@ intersphinx_mapping = {
         "https://flux-framework.readthedocs.io/projects/flux-security/en/latest/",
         None,
     ),
-    "workflow-examples": (
-        "https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/",
-        None,
-    ),
 }
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
Problem: There's no advice for how to run batch jobs that are resilent to node failure.

Add an entry in the FAQ.