### PR TITLE
Minor doc fixes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.abspath("."))
 # -- Project information -----------------------------------------------------
 
 project = "Flux"
-copyright = """Copyright 2014-2023 Lawrence Livermore National Security, LLC and Flux developers.
+copyright = """2014-2023 Lawrence Livermore National Security, LLC and Flux developers.
 
 SPDX-License-Identifier: LGPL-3.0"""
 author = "This page is maintained by the Flux Framework community."

--- a/guides/learning_guide.rst
+++ b/guides/learning_guide.rst
@@ -1058,7 +1058,7 @@ and deployed them, and they continue to add features. Similar expectations apply
 the Flux framework as development effort and feature enhancements continue.
 
 A key challenge for Flux includes the effort required for users to port their legacy
-applications and workflows to the flexible and modern Flux fraemwork. Although the
+applications and workflows to the flexible and modern Flux framework. Although the
 Flux framework is designed to be extremely user-friendly and easy to understand,
 the transition of legacy applications still requires some amounts of effort and
 developer bandwidth. This is because of the complex dependencies that could


### PR DESCRIPTION
I'm a little confused on why the typo wasn't picked up by aspell or typos, whichever we're running here. When I ran typos by hand nothing unexpected showed up.

The double copyright might also be a problem in all our framework repos that use RTD for docs.

Closes #299