### PR TITLE
doc: remove `jinja2<3.1` requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ sphinxcontrib-spelling
 sphinx-rtd-theme>=0.5.2
 sphinx-copybutton
 docutils
-Jinja2<3.1
 markupsafe==2.0.1
 sphinx_immaterial
 pydantic


### PR DESCRIPTION
#### Problem

GitHub dependabot is reporting moderate security vulnerabilities detected with `jinja2 < 3.1.4`, but flux-docs has `jinja2<3.1.0` listed in its `requirements.txt` file.

---

This PR removes the `jinja2` version requirement from `requirements.txt`.