### PR TITLE
`conf.py`: remove 2023 from copyright date range

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.abspath("."))
 # -- Project information -----------------------------------------------------
 
 project = "Flux"
-copyright = """2014-2023 Lawrence Livermore National Security, LLC and Flux developers.
+copyright = """2014 Lawrence Livermore National Security, LLC and Flux developers.
 
 SPDX-License-Identifier: LGPL-3.0"""
 author = "This page is maintained by the Flux Framework community."


### PR DESCRIPTION
#### Problem

The copyright dates on flux-docs specifies a range of years (2014-2023), but this copyright is still active.

---

This PR removes 2023 from the copyright and just leave the starting year (which is consistent with the copyright dates throughout the various flux projects).