### PR TITLE
`conf.py`: remove double `.append()` call

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -205,7 +205,6 @@ extensions.append("sphinx_immaterial")
 # html_context = sphinx_immaterial.get_html_context()
 html_css_files = ["custom.css"]
 
-extensions.append("sphinx_immaterial")
 html_theme = "sphinx_immaterial"
 
 # material theme options (see theme.conf for more information)


### PR DESCRIPTION
#### Problem

There is an extra `.append()` call to add the `"sphinx_immaterial"` extension.

---

This PR just removes the extra call.