### PR TITLE
update references to `flux job cancel`

### DIFF
--- a/faqs.rst
+++ b/faqs.rst
@@ -69,7 +69,7 @@ F58 to another using the :core:man1:`flux-job` ``id`` subcommand, e.g.
 
   $ flux submit sleep 3600 | flux job id --to=words
   airline-alibi-index--tuna-maximum-adam
-  $ flux job cancel airline-alibi-index--tuna-maximum-adam
+  $ flux cancel airline-alibi-index--tuna-maximum-adam
 
 With copy-and-paste, auto-completion, globbing, etc., it shouldn't be necessary
 to *type* a job ID with the ``ƒ`` prefix that often, but should you need to,

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -453,7 +453,7 @@ including
 
 .. code-block:: console
 
-  $ flux job cancel ƒMjstRfzF
+  $ flux cancel ƒMjstRfzF
 
 or
 

--- a/tutorials/commands/flux-jobs.rst
+++ b/tutorials/commands/flux-jobs.rst
@@ -44,7 +44,7 @@ Let's submit some jobs to the Flux instance.
     f2TREX7Cj
     f2TRG16V5
     f2TRHV5mR
-    $ flux job cancel f2TRHV5mR
+    $ flux cancel f2TRHV5mR
 
 In the above we have submitted a number of jobs.  First we submit two jobs that
 run ``/bin/true``, then we run two jobs that run ``/bin/false``.  If you are
@@ -53,7 +53,7 @@ duplicates of the job you just submitted.  We also specify the ``--wait`` comman
 to wait for those jobs to finish before moving on.
 
 Next we submit 8 ``sleep`` commands of infinite length.  Then for fun, we cancel
-one of those jobs via ``flux job cancel``.
+one of those jobs via ``flux cancel``.
 
 -----------------
 Basic Job Listing


### PR DESCRIPTION
Problem: `flux job cancel` has been deprecated for awhile, but a few references remain in the docs.

Update calls to `flux job cancel` to use `flux cancel` instead.