### PR TITLE
mergify: update YAML config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,29 +1,25 @@
 queue_rules:
   - name: default
-    queue_conditions:
-      - base=master
-      - status-success="validate commits"
-      - label="merge-when-passing"
-      - label!="work-in-progress"
-      - "approved-reviews-by=@flux-framework/docs"
-      - "#approved-reviews-by>0"
-      - "#changes-requested-reviews-by=0"
-      - -title~=^\[*[Ww][Ii][Pp]
-    merge_conditions:
-      - base=master
-      - status-success="docs/readthedocs.org:flux-framework"
-      - status-success="validate commits"
-      - label="merge-when-passing"
-      - label!="work-in-progress"
-      - "approved-reviews-by=@flux-framework/docs"
-      - "#approved-reviews-by>0"
-      - "#changes-requested-reviews-by=0"
-      - -title~=^\[*[Ww][Ii][Pp]
-    merge_method: merge
+    batch_size: 1
     update_method: rebase
+    merge_method: merge
+
+# Avoid temporary branches created by mergify for parallel checks
+# These do not work with the pr-validator since the temporary PR
+# branch is updated with a merge commit.
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
-  - name: refactored queue action rule
-    conditions: []
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~="^\[*(WIP|wip)"
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
     actions:
       queue:
+        name: default


### PR DESCRIPTION
#### Problem

Mergify is complaining that the setting to require branches to be up to date before merging is not compatible with draft PR checks.

---

This PR updates the Mergify configuration to enable in-place checks by setting `merge_queue.max_parallel_checks` to 1 and setting every queue_rule's `batch_size` to 1.

I noticed that status checks are not added or configured for this repo, so perhaps we should set that up before merging this PR since it removes the `status-success` checks in the `conditions` section.

Because this is making a change to mergify config, this will need a manual merge.