### PR TITLE
remove references to `--mpibind=off`

### DIFF
--- a/faqs.rst
+++ b/faqs.rst
@@ -182,9 +182,8 @@ Why are resources missing in foreign-launched Flux?
 When Flux discovers resources via
 `hwloc <https://www.open-mpi.org/projects/hwloc/>`_, it honors the current
 core and GPU bindings, so if resources are missing, affinity and binding
-from the parent resource manager should be checked.  In Slurm, try
-``--mpibind=off``, in LSF jsrun, try ``--bind=none``.
-
+from the parent resource manager should be checked.  If a competing plugin
+(such as `mpibind`) is determining affinity, try turning it off.
 
 .. _overcommit_resources:
 

--- a/jobs/batch.rst
+++ b/jobs/batch.rst
@@ -123,7 +123,7 @@ An example sbatch script:
   #!/bin/sh
   #SBATCH -N 4
 
-  srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --mpi=none --mpibind=off flux start flux_batch.sh
+  srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --mpi=none flux start flux_batch.sh
 
 .. note::
    ``--pty`` is not used in this case because this option
@@ -183,7 +183,7 @@ First Come First Served (FCFS).
 
     queue-policy = "easy"
 
-  $ srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --pty --mpi=none --mpibind=off flux start -o,--config-path=./
+  $ srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --pty --mpi=none flux start -o,--config-path=./
 
 
 ``sched-fluxion-qmanager`` is the one of the modules from Fluxion and

--- a/tutorials/commands/ssh-across-clusters.rst
+++ b/tutorials/commands/ssh-across-clusters.rst
@@ -19,7 +19,7 @@ and run ``flux start`` via our job manager. Here we might be on a login node:
 
     # Slurm specific
     $ salloc -N4 --exclusive
-    $ srun -N4 -n4 --pty --mpibind=off flux start
+    $ srun -N4 -n4 --pty flux start
 
 And then we get our allocation! You might adapt this command to be more specific to your resource manager. E.g., Slurm uses srun.
 After you run ``flux start``, you are inside of a Flux instance on your allocation!


### PR DESCRIPTION
Problem: the `--mpibind=off` option is specific to LLNL and could be confusing in project-wide docs for non-LLNL users.

Solution: remove that flag from slurm commands. Update docs with helpful suggestions where appropriate.

Fixes #99

Anecdotally, I haven't been turning mpibind off recently when I run flux under slurm and it seems to work fine. Maybe this is outdated advice anyway?
```
  mutt6 ~ $ srun -N4 -n4 --mpi=none --pty flux start
(s=4,d=0)  mutt90 ~ $ flux resource list
     STATE NNODES NCORES NGPUS NODELIST
      free      4    448     0 mutt[90-93]
 allocated      0      0     0
      down      0      0     0
 ```